### PR TITLE
new hook for last.fm individual artist data

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Rhizome</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,8 +4,9 @@ import { GraphControls } from './components/GraphControls'
 import { Waypoints, Undo2 } from 'lucide-react'
 import { BreadcrumbHeader } from './components/BreadcrumbHeader'
 import { Button, buttonVariants } from "@/components/ui/button"
-import useArtists from "@/hooks/useArtists";
+import useGenreArtists from "@/hooks/useGenreArtists";
 import useGenres from "@/hooks/useGenres";
+import useArtist from "@/hooks/useArtist";
 import ArtistsForceGraph from "@/components/ArtistsForceGraph";
 import GenresForceGraph from "@/components/GenresForceGraph";
 import {BasicNode} from "@/types";
@@ -17,7 +18,8 @@ function App() {
   const [selectedGenre, setSelectedGenre] = useState<string | undefined>(undefined);
   const [selectedArtist, setSelectedArtist] = useState<BasicNode | undefined>(undefined);
   const { genres, genreLinks, genresLoading, genresError } = useGenres();
-  const { artists, artistLinks, artistsLoading, artistsError } = useArtists(selectedGenre);
+  const { artists, artistLinks, artistsLoading, artistsError } = useGenreArtists(selectedGenre);
+  const { artistData, artistLoading, artistError } = useArtist(selectedArtist?.id);
 
   return (
     <div className="relative min-h-screen bg-gray-100">
@@ -60,7 +62,6 @@ function App() {
     />
   </AnimatePresence>
 )}
-
     </div>
   )
 }

--- a/src/hooks/useArtist.tsx
+++ b/src/hooks/useArtist.tsx
@@ -1,0 +1,34 @@
+import {useEffect, useState} from "react";
+import {LastFMArtistJSON} from "@/types";
+import axios, {AxiosError} from "axios";
+
+const url = 'http://localhost:3000/artists/data/';
+
+const useArtist = (mbid?: string) => {
+    const [artistData, setArtistData] = useState<LastFMArtistJSON>();
+    const [artistLoading, setArtistLoading] = useState(true);
+    const [artistError, setArtistError] = useState<AxiosError>();
+
+    const fetchArtist = async () => {
+        if (mbid) {
+            setArtistLoading(true);
+            try {
+                const response = await axios.get(`${url}${mbid}`);
+                setArtistData(response.data);
+            } catch (err) {
+                if (err instanceof AxiosError) {
+                    setArtistError(err);
+                }
+            }
+            setArtistLoading(false);
+        }
+    }
+
+    useEffect(() => {
+        fetchArtist();
+    }, [mbid]);
+
+    return { artistData, artistLoading, artistError };
+}
+
+export default useArtist;

--- a/src/hooks/useGenreArtists.tsx
+++ b/src/hooks/useGenreArtists.tsx
@@ -4,7 +4,7 @@ import axios, {AxiosError} from "axios";
 
 const url = 'http://localhost:3000/artists/';
 
-const useArtists = (genre?: string) => {
+const useGenreArtists = (genre?: string) => {
     const [artists, setArtists] = useState<Artist[]>([]);
     const [artistLinks, setArtistLinks] = useState<NodeLink[]>([]);
     const [artistsLoading, setArtistsLoading] = useState(true);
@@ -33,4 +33,4 @@ const useArtists = (genre?: string) => {
     return { artists, artistsLoading, artistsError, artistLinks };
 }
 
-export default useArtists;
+export default useGenreArtists;

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,3 +41,30 @@ export interface NodeLink {
     source: string;
     target: string;
 }
+
+export interface LastFMArtistJSON {
+    name: string;
+    mbid: string;
+    image: LastFMImage[];
+    ontour: boolean;
+    stats: LastFMStats;
+    bio: LastFMBio;
+    similar: string[];
+    date: string;
+}
+
+export interface LastFMImage {
+    link: string;
+    size: string;
+}
+
+export interface LastFMStats {
+    listeners: number;
+    playcount: number;
+}
+
+export interface LastFMBio {
+    link: string;
+    summary: string;
+    content: string;
+}


### PR DESCRIPTION
created a hook to get artist data from last.fm. This is for the artist panel when you click on an artist. It's simpler and more appropriate then using musicbrainz imo. This is the data you you get:

```tsx
export interface LastFMArtistJSON {
    name: string;
    mbid: string;
    image: LastFMImage[];
    ontour: boolean;
    stats: LastFMStats;
    bio: LastFMBio;
    similar: string[];
    date: string;
}

export interface LastFMImage {
    link: string;
    size: string;
}

export interface LastFMStats {
    listeners: number;
    playcount: number;
}

export interface LastFMBio {
    link: string;
    summary: string;
    content: string;
}
```