### PR TITLE
optional .env file to easily switch between a local and hosted server

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+VITE_SERVER_URL=https://rhizome-server-production.up.railway.app
+VITE_LOCALHOST=http://localhost:3000
+VITE_USE_LOCAL_SERVER=false

--- a/src/hooks/useArtist.tsx
+++ b/src/hooks/useArtist.tsx
@@ -1,8 +1,11 @@
 import {useEffect, useState} from "react";
 import {LastFMArtistJSON} from "@/types";
 import axios, {AxiosError} from "axios";
+import {envBoolean} from "@/lib/utils";
 
-const url = `https://rhizome-server-production.up.railway.app/artists/data/`;
+const url = envBoolean(import.meta.env.VITE_USE_LOCAL_SERVER)
+    ? import.meta.env.VITE_LOCALHOST
+    : import.meta.env.VITE_SERVER_URL || `https://rhizome-server-production.up.railway.app`;
 
 const useArtist = (mbid?: string) => {
     const [artistData, setArtistData] = useState<LastFMArtistJSON>();
@@ -13,7 +16,7 @@ const useArtist = (mbid?: string) => {
         if (mbid) {
             setArtistLoading(true);
             try {
-                const response = await axios.get(`${url}${mbid}`);
+                const response = await axios.get(`${url}/artists/data/${mbid}`);
                 setArtistData(response.data);
                 setArtistError(undefined);
             } catch (err) {

--- a/src/hooks/useGenreArtists.tsx
+++ b/src/hooks/useGenreArtists.tsx
@@ -1,8 +1,11 @@
 import {useEffect, useState} from "react";
 import {Artist, NodeLink} from "@/types";
 import axios, {AxiosError} from "axios";
+import {envBoolean} from "@/lib/utils";
 
-const url = `https://rhizome-server-production.up.railway.app/artists/`;
+const url = envBoolean(import.meta.env.VITE_USE_LOCAL_SERVER)
+    ? import.meta.env.VITE_LOCALHOST
+    : import.meta.env.VITE_SERVER_URL || `https://rhizome-server-production.up.railway.app`;
 
 const useGenreArtists = (genre?: string) => {
     const [artists, setArtists] = useState<Artist[]>([]);
@@ -14,7 +17,7 @@ const useGenreArtists = (genre?: string) => {
         if (genre) {
             setArtistsLoading(true);
             try {
-                const response = await axios.get(`${url}"${genre}"`);
+                const response = await axios.get(`${url}/artists/"${genre}"`);
                 setArtists(response.data.artists);
                 setArtistLinks(response.data.links);
             } catch (err) {

--- a/src/hooks/useGenres.tsx
+++ b/src/hooks/useGenres.tsx
@@ -1,8 +1,11 @@
 import {useEffect, useState} from "react";
 import {Genre, NodeLink} from "@/types";
 import axios, {AxiosError} from "axios";
+import {envBoolean} from "@/lib/utils";
 
-const url = `https://rhizome-server-production.up.railway.app/genres`;
+const url = envBoolean(import.meta.env.VITE_USE_LOCAL_SERVER)
+    ? import.meta.env.VITE_LOCALHOST
+    : import.meta.env.VITE_SERVER_URL || `https://rhizome-server-production.up.railway.app`;
 
 const useGenres = () => {
     const [genres, setGenres] = useState<Genre[]>([]);
@@ -13,7 +16,7 @@ const useGenres = () => {
     const fetchGenres = async () => {
         setGenresLoading(true);
         try {
-            const response = await axios.get(url);
+            const response = await axios.get(`${url}/genres`);
             setGenres(response.data.genres);
             setGenreLinks(response.data.links);
         } catch (err) {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -16,3 +16,7 @@ export const formatDate = (dateString: string) => {
 
 export const formatNumber = (value: number) =>
   new Intl.NumberFormat('en-US').format(value);
+
+export const envBoolean = (value: string) => {
+  return value && (value.toLowerCase() === 'true' || parseInt(value) === 1);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,14 +27,14 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
+    "module": "es2022",                                /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "node",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    "types": ["vite/client"],                                      /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */


### PR DESCRIPTION
use the local server by changing the `VITE_USE_LOCAL_SERVER` variable:

```dotenv
VITE_SERVER_URL=https://rhizome-server-production.up.railway.app
VITE_LOCALHOST=http://localhost:3000
VITE_USE_LOCAL_SERVER=false
```