### PR TITLE
Similar artists graph

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 VITE_SERVER_URL=https://rhizome-server-production.up.railway.app
 VITE_LOCALHOST=http://localhost:3000
-VITE_USE_LOCAL_SERVER=true
+VITE_USE_LOCAL_SERVER=false

--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 VITE_SERVER_URL=https://rhizome-server-production.up.railway.app
 VITE_LOCALHOST=http://localhost:3000
-VITE_USE_LOCAL_SERVER=false
+VITE_USE_LOCAL_SERVER=true

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -202,6 +202,7 @@ function App() {
                     onArtistSelect={createSimilarArtistGraph}
                     setQuery={setQuery}
                     searchableItems={searchableItems}
+                    graphState={graph}
                 />
               </motion.div>
             </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import { Gradient } from './components/Gradient';
 import { Search } from './components/Search';
 import {generateArtistLinks} from "@/lib/utils";
 import useLastFMArtistSearch from "@/hooks/useLastFMArtistSearch";
+import {s} from "framer-motion/m";
 
 function App() {
   const [selectedGenre, setSelectedGenre] = useState<string | undefined>(undefined);
@@ -44,8 +45,7 @@ function App() {
   }, [artists]);
 
   useEffect(() => {
-    if (canCreateSimilarArtistGraph && artistData?.similar && selectedArtist) {
-      const prevSimilarArtists = artists.map(a => a.name).slice(1);
+    if (canCreateSimilarArtistGraph && artistData?.similar && selectedArtist && selectedArtist.name === artistData.name) {
       const similarArtists = [selectedArtist];
       artistData.similar.forEach((s, i) => {
         similarArtists.push({ id: i.toString(), name: s, tags: [] });
@@ -55,11 +55,9 @@ function App() {
         setCurrentArtistLinks(generateArtistLinks(selectedArtist, similarArtists.length));
         setGraph('artists');
       }
-      if (JSON.stringify(prevSimilarArtists) === JSON.stringify(similarArtists) ) {
-        setCanCreateSimilarArtistGraph(false);
-      }
+      setCanCreateSimilarArtistGraph(false);
     }
-  }, [artistData, canCreateSimilarArtistGraph, selectedArtist]);
+  }, [artistData, canCreateSimilarArtistGraph]);
 
   const setArtistFromName = (name: string) => {
     const artist = artists.find((artist) => artist.name === name);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,7 @@ function App() {
   const [currentArtists, setCurrentArtists] = useState<Artist[]>([]);
   const [currentArtistLinks, setCurrentArtistLinks] = useState<NodeLink[]>([]);
   const [query, setQuery] = useState<string>('');
-  const [pendingSimilarArtistName, setPendingSimilarArtistName] = useState<string | undefined>(undefined);
+  const [canCreateSimilarArtistGraph, setCanCreateSimilarArtistGraph] = useState<boolean>(false);
   const { genres, genreLinks, genresLoading, genresError } = useGenres();
   const { artists, artistLinks, artistsLoading, artistsError } = useGenreArtists(selectedGenre);
   const { artistData, artistLoading, artistError } = useArtist(selectedArtist);
@@ -44,26 +44,22 @@ function App() {
   }, [artists]);
 
   useEffect(() => {
-    if (pendingSimilarArtistName && artistData?.similar && selectedArtist) {
+    if (canCreateSimilarArtistGraph && artistData?.similar && selectedArtist) {
       const prevSimilarArtists = artists.map(a => a.name).slice(1);
       const similarArtists = [selectedArtist];
       artistData.similar.forEach((s, i) => {
         similarArtists.push({ id: i.toString(), name: s, tags: [] });
       });
-
       if (similarArtists.length > 1) {
         setCurrentArtists(similarArtists);
         setCurrentArtistLinks(generateArtistLinks(selectedArtist, similarArtists.length));
         setGraph('artists');
       }
-
-      // Clear the pending state
       if (JSON.stringify(prevSimilarArtists) === JSON.stringify(similarArtists) ) {
-        setPendingSimilarArtistName(undefined);
+        setCanCreateSimilarArtistGraph(false);
       }
-
     }
-  }, [artistData, pendingSimilarArtistName, selectedArtist]);
+  }, [artistData, canCreateSimilarArtistGraph, selectedArtist]);
 
   const setArtistFromName = (name: string) => {
     const artist = artists.find((artist) => artist.name === name);
@@ -103,11 +99,9 @@ function App() {
         tags: []
       }
     }
-
-    // Set the selected artist and mark that we want to create a similar artist graph
     setSelectedArtist(artist);
     setShowArtistCard(true);
-    setPendingSimilarArtistName(artistName);
+    setCanCreateSimilarArtistGraph(true);
   }
 
   const searchableItems = useMemo(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -104,17 +104,21 @@ function App() {
     setCanCreateSimilarArtistGraph(true);
   }
 
-  const searchableItems = useMemo(() => {
-    // Create a Set of current artist names for O(1) lookup
-    const currentArtistNames = new Set(currentArtists.map(artist => artist.name));
+  const currentArtistNames = useMemo(
+      () => new Set(currentArtists.map(({ name }) => name)),
+      [currentArtists]
+  );
 
-    // Filter out search results that have the same name as current artists
-    const filteredSearchResults = searchResults.filter(
-        searchResult => !currentArtistNames.has(searchResult.name)
+  const filteredSearchResults = useMemo(() => {
+    return searchResults.filter(
+        ({ name }) => !currentArtistNames.has(name)
     );
+  }, [searchResults, currentArtistNames]);
 
-    return [...genres, ...currentArtists, ...filteredSearchResults];
-  }, [genres, currentArtists, searchResults]);
+  const searchableItems = useMemo(() => {
+    return (genres as BasicNode[])
+        .concat(currentArtists as BasicNode[], filteredSearchResults as BasicNode[]);
+  }, [genres, currentArtists, filteredSearchResults]);
 
   console.log("App render", {
   selectedGenre,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,7 @@ function App() {
 
   useEffect(() => {
     if (pendingSimilarArtistName && artistData?.similar && selectedArtist) {
+      const prevSimilarArtists = artists.map(a => a.name).slice(1);
       const similarArtists = [selectedArtist];
       artistData.similar.forEach((s, i) => {
         similarArtists.push({ id: i.toString(), name: s, tags: [] });
@@ -57,7 +58,10 @@ function App() {
       }
 
       // Clear the pending state
-      setPendingSimilarArtistName(undefined);
+      if (JSON.stringify(prevSimilarArtists) === JSON.stringify(similarArtists) ) {
+        setPendingSimilarArtistName(undefined);
+      }
+
     }
   }, [artistData, pendingSimilarArtistName, selectedArtist]);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,9 +81,7 @@ function App() {
       }
     }
     onArtistNodeClick(artist);
-    while (artistLoading) {
 
-    }
     const similarArtists = [artist];
     artistData?.similar.forEach((s, i) => {
       similarArtists.push({ id: i.toString(), name: s, tags: [] });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -105,7 +105,15 @@ function App() {
   }
 
   const searchableItems = useMemo(() => {
-    return [...genres, ...currentArtists, ...searchResults];
+    // Create a Set of current artist names for O(1) lookup
+    const currentArtistNames = new Set(currentArtists.map(artist => artist.name));
+
+    // Filter out search results that have the same name as current artists
+    const filteredSearchResults = searchResults.filter(
+        searchResult => !currentArtistNames.has(searchResult.name)
+    );
+
+    return [...genres, ...currentArtists, ...filteredSearchResults];
   }, [genres, currentArtists, searchResults]);
 
   console.log("App render", {

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -22,12 +22,6 @@ export function Search({ onGenreSelect, onArtistSelect, setQuery, searchableItem
   const [inputValue, setInputValue] = useState<string>("")
   const { recentSelections, addRecentSelection, removeRecentSelection } = useRecentSelections()
 
-  // const allSearchableItems = React.useMemo(() => {
-  //   const genreItems = genres.map((genre: Genre) => ({ id: genre.id, name: genre.name, type: 'genre' as const }));
-  //   const artists = searchResults.map(artist => ({ id: artist.mbid, name: artist.name, type: 'artist' as const }));
-  //   return [...genreItems, ...artists];
-  // }, [genres, searchResults]);
-
   // Debouncing
   useEffect(() => {
     const timeout = setTimeout(() => {

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -81,7 +81,11 @@ export function Search({ onGenreSelect, onArtistSelect, setQuery, searchableItem
           </Badge> */}
         </Button>
       </motion.div>
-      <CommandDialog open={open} onOpenChange={setOpen}>
+      <CommandDialog
+          key={searchableItems.length}
+          open={open}
+          onOpenChange={setOpen}
+      >
         <CommandInput placeholder="Search..." value={inputValue} onValueChange={setInputValue} />
         <CommandList>
           <CommandEmpty>{inputValue ? "No results found." : "Start typing to search..."}</CommandEmpty>

--- a/src/hooks/useArtist.tsx
+++ b/src/hooks/useArtist.tsx
@@ -9,7 +9,7 @@ const url = envBoolean(import.meta.env.VITE_USE_LOCAL_SERVER)
 
 const useArtist = (artist?: Artist) => {
     const [artistData, setArtistData] = useState<LastFMArtistJSON>();
-    const [artistLoading, setArtistLoading] = useState(true);
+    const [artistLoading, setArtistLoading] = useState(false);
     const [artistError, setArtistError] = useState<AxiosError>();
 
     const fetchArtist = async () => {

--- a/src/hooks/useArtist.tsx
+++ b/src/hooks/useArtist.tsx
@@ -30,7 +30,8 @@ const useArtist = (artist?: Artist) => {
                 } catch (err) {
 
                 }
-                setArtistData({...response.data, image: image ? image.data : undefined });
+                const data = {...response.data, image: image ? image.data : undefined}
+                setArtistData(data);
                 setArtistError(undefined);
             }
             setArtistLoading(false);

--- a/src/hooks/useGenreArtists.tsx
+++ b/src/hooks/useGenreArtists.tsx
@@ -10,7 +10,7 @@ const url = envBoolean(import.meta.env.VITE_USE_LOCAL_SERVER)
 const useGenreArtists = (genre?: string) => {
     const [artists, setArtists] = useState<Artist[]>([]);
     const [artistLinks, setArtistLinks] = useState<NodeLink[]>([]);
-    const [artistsLoading, setArtistsLoading] = useState(true);
+    const [artistsLoading, setArtistsLoading] = useState(false);
     const [artistsError, setArtistsError] = useState<AxiosError>();
 
     const fetchArtists = async () => {

--- a/src/hooks/useLastFMArtistSearch.tsx
+++ b/src/hooks/useLastFMArtistSearch.tsx
@@ -1,0 +1,37 @@
+import {envBoolean} from "@/lib/utils";
+import {useEffect, useState} from "react";
+import {LastFMSearchArtistData} from "@/types";
+import axios, {AxiosError} from "axios";
+
+const url = envBoolean(import.meta.env.VITE_USE_LOCAL_SERVER)
+    ? import.meta.env.VITE_LOCALHOST
+    : import.meta.env.VITE_SERVER_URL || `https://rhizome-server-production.up.railway.app`;
+
+const useLastFMArtistSearch = (query?: string) => {
+    const [searchResults, setSearchResults] = useState<LastFMSearchArtistData[]>([]);
+    const [searchError, setSearchError] = useState<AxiosError>();
+    const [searchLoading, setSearchLoading] = useState(false);
+
+    const search = async () => {
+        if (query) {
+            setSearchLoading(true);
+            try {
+                const response = await axios.get(`${url}/artists/search/${query}`);
+                setSearchResults(response.data);
+            } catch (err) {
+                if (err instanceof AxiosError) {
+                    setSearchError(err);
+                }
+            }
+            setSearchLoading(false);
+        }
+    }
+
+    useEffect(() => {
+        search();
+    }, [query]);
+
+    return { searchResults, searchLoading, searchError };
+}
+
+export default useLastFMArtistSearch;

--- a/src/hooks/useRecentSelections.tsx
+++ b/src/hooks/useRecentSelections.tsx
@@ -1,16 +1,11 @@
 import { useState, useEffect } from 'react';
-
-interface RecentSelection {
-  id: string;
-  name: string;
-  type: 'artist' | 'genre';
-}
+import {BasicNode} from "@/types";
 
 const LOCAL_STORAGE_KEY = 'recentSelections';
 const MAX_RECENT_SELECTIONS = 5;
 
 export function useRecentSelections() {
-  const [recentSelections, setRecentSelections] = useState<RecentSelection[]>([]);
+  const [recentSelections, setRecentSelections] = useState<BasicNode[]>([]);
 
   useEffect(() => {
     try {
@@ -23,7 +18,7 @@ export function useRecentSelections() {
     }
   }, []);
 
-  const addRecentSelection = (selection: RecentSelection) => {
+  const addRecentSelection = (selection: BasicNode) => {
     setRecentSelections((prevSelections) => {
       const newSelections = [selection, ...prevSelections.filter(s => s.id !== selection.id)];
       const limitedSelections = newSelections.slice(0, MAX_RECENT_SELECTIONS);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
-import {Artist, BasicNode, Genre, LastFMArtistJSON, LastFMSearchArtistData} from "@/types";
+import {Artist, BasicNode, Genre, LastFMArtistJSON, LastFMSearchArtistData, NodeLink} from "@/types";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -26,6 +26,14 @@ export const generateArtistLinks = (artist: Artist, similarCount: number) => {
   const links = [];
   for (let i = 0; i < similarCount - 1; i++) {
     links.push({ source: artist.id, target: i.toString() });
+  }
+  return links;
+}
+
+export const generateSimilarLinks = (artists: Artist[]) => {
+  const links: NodeLink[] = [];
+  for (let i = 1; i < artists.length; i++) {
+    links.push({ source: artists[0].id, target: artists[i].id });
   }
   return links;
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
+import {Artist, BasicNode, Genre, LastFMArtistJSON, LastFMSearchArtistData} from "@/types";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -19,4 +20,16 @@ export const formatNumber = (value: number) =>
 
 export const envBoolean = (value: string) => {
   return value && (value.toLowerCase() === 'true' || parseInt(value) === 1);
+}
+
+export const generateArtistLinks = (artist: Artist, similarCount: number) => {
+  const links = [];
+  for (let i = 0; i < similarCount; i++) {
+    links.push({ source: artist.id, target: i.toString() });
+  }
+  return links;
+}
+
+export const isGenre = (item: BasicNode) => {
+  return "artistCount" in item;
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -24,7 +24,7 @@ export const envBoolean = (value: string) => {
 
 export const generateArtistLinks = (artist: Artist, similarCount: number) => {
   const links = [];
-  for (let i = 0; i < similarCount; i++) {
+  for (let i = 0; i < similarCount - 1; i++) {
     links.push({ source: artist.id, target: i.toString() });
   }
   return links;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,4 @@
-export interface Genre {
-    id: string;
-    name: string;
+export interface Genre extends BasicNode {
     artistCount: number;
     subgenre_of: BasicNode[];
     influenced_genres: BasicNode[];
@@ -22,9 +20,7 @@ export interface Tag {
     count: number;
 }
 
-export interface Artist {
-    id: string;
-    name: string;
+export interface Artist extends BasicNode {
     tags: Tag[];
     location?: string;
     startDate?: string;
@@ -48,20 +44,13 @@ export interface NodeLink {
     target: string;
 }
 
-export interface LastFMArtistJSON {
-    name: string;
-    mbid: string;
+export interface LastFMArtistJSON extends BasicNode {
     image: string;
     ontour: boolean;
     stats: LastFMStats;
     bio: LastFMBio;
     similar: string[];
     date: string; // this is for caching
-}
-
-export interface LastFMImage {
-    link: string;
-    size: string;
 }
 
 export interface LastFMStats {
@@ -76,3 +65,7 @@ export interface LastFMBio {
 }
 
 export type GraphType = 'genres' | 'artists';
+
+export interface LastFMSearchArtistData extends BasicNode {
+    listeners: number;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,7 +64,7 @@ export interface LastFMBio {
     content: string;
 }
 
-export type GraphType = 'genres' | 'artists';
+export type GraphType = 'genres' | 'artists' | 'similarArtists';
 
 export interface LastFMSearchArtistData extends BasicNode {
     listeners: number;


### PR DESCRIPTION
- Search for artists in the search bar
- Clicking on them brings up the artist and their similiar artists
- Clicking on similar artist does the same for that artist
- New graph state for this: `similarArtists`
- Based on last.fm data, so the start date isn't there
- Once graph controls are implemented, I wanna have it zoom in on that artist if you're in the artists (of a genre) graph and that artist is in there