### PR TITLE
Genres panel

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 VITE_SERVER_URL=https://rhizome-server-production.up.railway.app
 VITE_LOCALHOST=http://localhost:3000
-VITE_USE_LOCAL_SERVER=true
+VITE_USE_LOCAL_SERVER=false

--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 VITE_SERVER_URL=https://rhizome-server-production.up.railway.app
 VITE_LOCALHOST=http://localhost:3000
-VITE_USE_LOCAL_SERVER=false
+VITE_USE_LOCAL_SERVER=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,8 @@
         "react-responsive": "^10.0.1",
         "react-router": "^7.6.1",
         "tailwind-merge": "^3.3.0",
-        "typescript": "^5.8.3"
+        "typescript": "^5.8.3",
+        "vaul": "^1.1.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -5183,6 +5184,19 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vaul": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vaul/-/vaul-1.1.2.tgz",
+      "integrity": "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/vite": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "rizhome",
       "version": "0.0.0",
       "dependencies": {
+        "@radix-ui/react-checkbox": "^1.3.2",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-popover": "^1.1.14",
@@ -1083,6 +1084,36 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.2.tgz",
+      "integrity": "sha512-yd+dI56KZqawxKZrJ31eENUwqc1QSqg4OZ15rybGjF2ZNwMO+wCyHzAVLRp9qoYJf7kYy0YpZ2b0JCzJ42HZpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-popover": "^1.1.14",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "react-responsive": "^10.0.1",
     "react-router": "^7.6.1",
     "tailwind-merge": "^3.3.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vaul": "^1.1.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import {buildGenreTree, generateSimilarLinks, isParentGenre} from "@/lib/utils";
 import ClusteringPanel from "@/components/ClusteringPanel";
 import { ModeToggle } from './components/ModeToggle';
 import DisplayPanel from './components/DisplayPanel';
+import GenrePanel from './components/GenrePanel'
 
 function App() {
   const [selectedGenre, setSelectedGenre] = useState<Genre | undefined>(undefined);
@@ -193,6 +194,7 @@ function App() {
                 dagMode={dagMode} 
                 setDagMode={setDagMode} />
               <DisplayPanel />
+              <GenrePanel />
           </div>
         <GenresForceGraph
             graphData={currentGenres}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,6 +60,24 @@ function App() {
   }, [dagMode]);
 
   useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        if (showArtistCard) {
+          deselectArtist();
+        } else {
+          resetAppState();
+        }
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [showArtistCard]);
+
+  useEffect(() => {
     setCurrentArtists(artists);
     setCurrentArtistLinks(artistLinks);
   }, [artists]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -161,7 +161,27 @@ function App() {
             ? "max-w-[calc(100vw-32px)]  inline-flex flex-col gap-2 items-start"
             : " inline-flex flex-col gap-2 items-start"
         }>
-            <BreadcrumbHeader
+          <div className={`flex justify-center gap-3 ${graph !== 'genres' ? 'w-full' : ''}`}>
+              <ResetButton
+                onClick={() => resetAppState()}
+                show={graph !== 'genres'}
+              />
+              <motion.div
+                layout
+                // className={`${graph === 'artists' ? 'flex-grow' : ''}`}
+              >
+                <Search
+                    onGenreSelect={onGenreNodeClick}
+                    onArtistSelect={createSimilarArtistGraph}
+                    currentArtists={currentArtists}
+                    genres={genres}
+                    graphState={graph}
+                    selectedGenre={selectedGenre}
+                    selectedArtist={selectedArtist}
+                />
+              </motion.div>
+            </div>
+            {/* <BreadcrumbHeader
                 selectedGenre={selectedGenre ? selectedGenre.name : undefined}
                 selectedArtist={selectedArtist}
                 HomeIcon={Waypoints}
@@ -169,7 +189,7 @@ function App() {
                 showListView={showListView}
                 reset={resetAppState}
                 hideArtistCard={deselectArtist}
-            />
+            /> */}
             {/* <ListViewPanel
                 genres={genres}
                 onGenreClick={onGenreNodeClick}
@@ -233,26 +253,7 @@ function App() {
               deselectArtist={deselectArtist}
               similarFilter={similarArtistFilter}
             />
-            <div className={`flex justify-center gap-3 ${graph !== 'genres' ? 'w-full' : ''}`}>
-              <ResetButton
-                onClick={() => resetAppState()}
-                show={graph !== 'genres'}
-              />
-              <motion.div
-                layout
-                // className={`${graph === 'artists' ? 'flex-grow' : ''}`}
-              >
-                <Search
-                    onGenreSelect={onGenreNodeClick}
-                    onArtistSelect={createSimilarArtistGraph}
-                    currentArtists={currentArtists}
-                    genres={genres}
-                    graphState={graph}
-                    selectedGenre={selectedGenre}
-                    selectedArtist={selectedArtist}
-                />
-              </motion.div>
-            </div>
+            
             
           </motion.div>
         </AnimatePresence>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -193,6 +193,7 @@ function App() {
               <DisplayPanel />
               <GenrePanel 
               genres={genres}
+              genreClusterMode={genreClusterMode}
               />
           </div>
         <GenresForceGraph

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -194,7 +194,9 @@ function App() {
                 dagMode={dagMode} 
                 setDagMode={setDagMode} />
               <DisplayPanel />
-              <GenrePanel />
+              <GenrePanel 
+              genres={genres}
+              />
           </div>
         <GenresForceGraph
             graphData={currentGenres}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -248,6 +248,8 @@ function App() {
                     currentArtists={currentArtists}
                     genres={genres}
                     graphState={graph}
+                    selectedGenre={selectedGenre}
+                    selectedArtist={selectedArtist}
                 />
               </motion.div>
             </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -161,7 +161,7 @@ function App() {
             ? "max-w-[calc(100vw-32px)]  inline-flex flex-col gap-2 items-start"
             : " inline-flex flex-col gap-2 items-start"
         }>
-          <div className={`flex justify-center gap-3 ${graph !== 'genres' ? 'w-full' : ''}`}>
+          <div className={`md:flex hidden justify-center gap-3 ${graph !== 'genres' ? 'w-full' : ''}`}>
               <ResetButton
                 onClick={() => resetAppState()}
                 show={graph !== 'genres'}
@@ -253,7 +253,26 @@ function App() {
               deselectArtist={deselectArtist}
               similarFilter={similarArtistFilter}
             />
-            
+            <div className={`flex md:hidden justify-center gap-3 ${graph !== 'genres' ? 'w-full' : ''}`}>
+              <ResetButton
+                onClick={() => resetAppState()}
+                show={graph !== 'genres'}
+              />
+              <motion.div
+                layout
+                // className={`${graph === 'artists' ? 'flex-grow' : ''}`}
+              >
+                <Search
+                    onGenreSelect={onGenreNodeClick}
+                    onArtistSelect={createSimilarArtistGraph}
+                    currentArtists={currentArtists}
+                    genres={genres}
+                    graphState={graph}
+                    selectedGenre={selectedGenre}
+                    selectedArtist={selectedArtist}
+                />
+              </motion.div>
+            </div>
             
           </motion.div>
         </AnimatePresence>

--- a/src/components/AppSideBar.tsx
+++ b/src/components/AppSideBar.tsx
@@ -5,57 +5,19 @@ import {
   SidebarGroup,
   SidebarHeader,
   SidebarMenu,
-  SidebarMenuItem,
 } from "@/components/ui/sidebar"
-import { Button } from "@/components/ui/button";
-import { X } from "lucide-react";
-import { Artist, BasicNode, Genre } from "@/types";
-import { isGenre } from "@/lib/utils";
+import { Search } from "@/components/Search"
 
-interface AppSidebarProps {
-  recentSelections: BasicNode[];
-  onGenreSelect: (genre: Genre) => void;
-  onArtistSelect: (artist: Artist) => void;
-  removeRecentSelection: (id: string) => void;
-}
-
-export function AppSidebar({ recentSelections, onGenreSelect, onArtistSelect, removeRecentSelection }: AppSidebarProps) {
-  const onItemSelect = (selection: BasicNode) => {
-    if (isGenre(selection)) {
-      onGenreSelect(selection as Genre);
-    } else {
-      onArtistSelect(selection as Artist);
-    }
-  }
-
+export function AppSidebar() {
   return (
     <Sidebar className="absolute" variant="inset">
       <SidebarHeader />
       <SidebarContent>
-        <SidebarGroup heading="Recent Selections">
-          <SidebarMenu>
-            {recentSelections.map((selection) => (
-              <SidebarMenuItem
-                key={selection.id}
-                onClick={() => onItemSelect(selection)}
-                isActive={false}
-              >
-                <span>{selection.name}</span>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    removeRecentSelection(selection.id);
-                  }}
-                  className="h-auto p-1"
-                >
-                  <X className="h-4 w-4 text-muted-foreground" />
-                </Button>
-              </SidebarMenuItem>
-            ))}
-          </SidebarMenu>
-        </SidebarGroup>
+        <SidebarGroup />
+        {/* <SidebarMenu />
+         */}
+        
+        <SidebarGroup />
       </SidebarContent>
       <SidebarFooter />
     </Sidebar>

--- a/src/components/AppSideBar.tsx
+++ b/src/components/AppSideBar.tsx
@@ -1,0 +1,63 @@
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuItem,
+} from "@/components/ui/sidebar"
+import { Button } from "@/components/ui/button";
+import { X } from "lucide-react";
+import { Artist, BasicNode, Genre } from "@/types";
+import { isGenre } from "@/lib/utils";
+
+interface AppSidebarProps {
+  recentSelections: BasicNode[];
+  onGenreSelect: (genre: Genre) => void;
+  onArtistSelect: (artist: Artist) => void;
+  removeRecentSelection: (id: string) => void;
+}
+
+export function AppSidebar({ recentSelections, onGenreSelect, onArtistSelect, removeRecentSelection }: AppSidebarProps) {
+  const onItemSelect = (selection: BasicNode) => {
+    if (isGenre(selection)) {
+      onGenreSelect(selection as Genre);
+    } else {
+      onArtistSelect(selection as Artist);
+    }
+  }
+
+  return (
+    <Sidebar className="absolute" variant="inset">
+      <SidebarHeader />
+      <SidebarContent>
+        <SidebarGroup heading="Recent Selections">
+          <SidebarMenu>
+            {recentSelections.map((selection) => (
+              <SidebarMenuItem
+                key={selection.id}
+                onClick={() => onItemSelect(selection)}
+                isActive={false}
+              >
+                <span>{selection.name}</span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    removeRecentSelection(selection.id);
+                  }}
+                  className="h-auto p-1"
+                >
+                  <X className="h-4 w-4 text-muted-foreground" />
+                </Button>
+              </SidebarMenuItem>
+            ))}
+          </SidebarMenu>
+        </SidebarGroup>
+      </SidebarContent>
+      <SidebarFooter />
+    </Sidebar>
+  )
+}

--- a/src/components/ClusteringPanel.tsx
+++ b/src/components/ClusteringPanel.tsx
@@ -37,7 +37,7 @@ export default function ClusteringPanel({ clusterMode, setClusterMode, dagMode, 
                   <Spline />
                 </Button>
              </PopoverTrigger>
-            <PopoverContent side="left" align="start" className="w-full max-w-md">
+            <PopoverContent side="left" align="start" className="w-full w-sm">
                   <RadioGroup
                     value={clusterMode}
                     onValueChange={(value) => setClusterMode(value as GenreClusterMode)}

--- a/src/components/ClusteringPanel.tsx
+++ b/src/components/ClusteringPanel.tsx
@@ -33,14 +33,14 @@ export default function ClusteringPanel({ clusterMode, setClusterMode, dagMode, 
             <RadioGroup
                 value={clusterMode}
                 onValueChange={(value) => setClusterMode(value as GenreClusterMode)}
-                className="flex flex-col items-start w-full gap-1 dark:bg-background shadow-sm p-2 rounded-2xl border border-accent dark:border-border/50 bg-accent"
+                className="flex flex-col items-start w-full gap-1 dark:bg-background shadow-sm p-1 rounded-2xl border border-accent dark:border-border/50 bg-accent"
             >
                 {options.map((option) => (
                     <div key={option.id} className="w-full">
                         <label
                             htmlFor={option.id}
                             className={`flex items-start w-full gap-3 rounded-xl p-3 transition-colors cursor-pointer ${
-                                clusterMode === option.id ? "bg-gray-100 border-accent border dark:bg-accent" : "hover:bg-white/10 dark:hover:bg-black/10"
+                                clusterMode === option.id ? "bg-gray-200 border-accent border dark:bg-accent" : "hover:bg-white/10 dark:hover:bg-black/10"
                             }`}
                         >
                             <RadioGroupItem

--- a/src/components/ClusteringPanel.tsx
+++ b/src/components/ClusteringPanel.tsx
@@ -41,14 +41,15 @@ export default function ClusteringPanel({ clusterMode, setClusterMode, dagMode, 
                   <RadioGroup
                     value={clusterMode}
                     onValueChange={(value) => setClusterMode(value as GenreClusterMode)}
-                    className="flex flex-col items-start w-full gap-1 bg-background dark:bg-background rounded-2xl "
+                    className="flex flex-col items-start w-full gap-1 dark:bg-background shadow-xs p-2 rounded-xl border border-accent dark:border-border/50
+          bg-gray-50"
                   >
                       {options.map((option) => (
                         <div key={option.id} className="w-full">
                           <label
                             htmlFor={option.id}
                             className={`flex items-start w-full gap-3 rounded-xl p-3 transition-colors cursor-pointer ${
-                              clusterMode === option.id ? "bg-accent dark:bg-accent" : "hover:bg-white/10 dark:hover:bg-black/10"
+                              clusterMode === option.id ? "bg-gray-100 border-accent border dark:bg-accent" : "hover:bg-white/10 dark:hover:bg-black/10"
                             }`}
                           >
                             <RadioGroupItem

--- a/src/components/ClusteringPanel.tsx
+++ b/src/components/ClusteringPanel.tsx
@@ -3,14 +3,8 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { motion, AnimatePresence } from "framer-motion";
 import { Switch } from "@/components/ui/switch";
 import { Button } from "@/components/ui/button";
-import { useTheme } from "next-themes";
 import { Spline } from "lucide-react";
-import { useState } from "react";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover"
+import { ResponsivePanel } from "@/components/ResponsivePanel";
 
 interface ClusteringPanelProps {
     clusterMode: GenreClusterMode;
@@ -25,74 +19,69 @@ export default function ClusteringPanel({ clusterMode, setClusterMode, dagMode, 
         { id: "influence", label: "Influence", description: "Visualizes how genres have influenced each other over time, revealing historical connections and the evolution of musical styles." },
         { id: "fusion", label: "Fusion", description: "Highlights genres that have merged to create new, hybrid genres, like 'jazz fusion' or 'folk punk'." },
     ];
-    const [open, setOpen] = useState<boolean>(false);
-    return (
 
-        <Popover>
-          <div>
-             <PopoverTrigger asChild>
-               <Button className="bg-background backdrop-blur-xs rounded-full border border-border" variant="outline" size="icon" aria-label="Clustering Panel"
-               onClick={() => setOpen(prev => !prev)}>
-                  <span className="sr-only">Show Clustering Pannel</span>
-                  <Spline />
+    return (
+        <ResponsivePanel
+            trigger={
+                <Button className="bg-background backdrop-blur-xs rounded-full border border-border" variant="outline" size="icon" aria-label="Clustering Panel">
+                    <span className="sr-only">Show Clustering Panel</span>
+                    <Spline />
                 </Button>
-             </PopoverTrigger>
-            <PopoverContent side="left" align="start" className="w-full w-sm">
-                  <RadioGroup
-                    value={clusterMode}
-                    onValueChange={(value) => setClusterMode(value as GenreClusterMode)}
-                    className="flex flex-col items-start w-full gap-1 dark:bg-background shadow-sm p-2 rounded-2xl border border-accent dark:border-border/50
-          bg-accent"
-                  >
-                      {options.map((option) => (
-                        <div key={option.id} className="w-full">
-                          <label
+            }
+            className="w-full w-sm"
+        >
+            <RadioGroup
+                value={clusterMode}
+                onValueChange={(value) => setClusterMode(value as GenreClusterMode)}
+                className="flex flex-col items-start w-full gap-1 dark:bg-background shadow-sm p-2 rounded-2xl border border-accent dark:border-border/50 bg-accent"
+            >
+                {options.map((option) => (
+                    <div key={option.id} className="w-full">
+                        <label
                             htmlFor={option.id}
                             className={`flex items-start w-full gap-3 rounded-xl p-3 transition-colors cursor-pointer ${
-                              clusterMode === option.id ? "bg-gray-100 border-accent border dark:bg-accent" : "hover:bg-white/10 dark:hover:bg-black/10"
+                                clusterMode === option.id ? "bg-gray-100 border-accent border dark:bg-accent" : "hover:bg-white/10 dark:hover:bg-black/10"
                             }`}
-                          >
+                        >
                             <RadioGroupItem
-                              value={option.id}
-                              id={option.id}
-                              className="mt-1 sr-only"
+                                value={option.id}
+                                id={option.id}
+                                className="mt-1 sr-only"
                             />
                             <div className="flex flex-col items-start">
-                              <span className="text-md font-semibold leading-none text-gray-900 dark:text-gray-100">
-                                {option.label}
-                              </span>
+                                <span className="text-md font-semibold leading-none text-gray-900 dark:text-gray-100">
+                                    {option.label}
+                                </span>
                                 <AnimatePresence mode="wait" initial={false}>
-                                  {clusterMode === option.id && (
-                                    <motion.p
-                                    key={option.id}
-                                    initial={{ opacity: 0, height: 0, y: -10 }}
-                                    animate={{ opacity: 1, height: "auto", y: 0 }}
-                                    exit={{ opacity: 0, height: 0, y: -10 }}
-                                    transition={{
-                                      opacity: { duration: 0.2, ease: "easeOut" },
-                                      height: { duration: 0.2, ease: "easeOut" },
-                                      y: { duration: 0.2, ease: "easeOut" }
-                                    }}
-                                      className="text-sm text-gray-700 dark:text-gray-300 mt-1 text-left"
-                                    >
-                                      {option.description}
-                                    </motion.p>
-                                  )}
+                                    {clusterMode === option.id && (
+                                        <motion.p
+                                            key={option.id}
+                                            initial={{ opacity: 0, height: 0, y: -10 }}
+                                            animate={{ opacity: 1, height: "auto", y: 0 }}
+                                            exit={{ opacity: 0, height: 0, y: -10 }}
+                                            transition={{
+                                                opacity: { duration: 0.2, ease: "easeOut" },
+                                                height: { duration: 0.2, ease: "easeOut" },
+                                                y: { duration: 0.2, ease: "easeOut" }
+                                            }}
+                                            className="text-sm text-gray-700 dark:text-gray-300 mt-1 text-left"
+                                        >
+                                            {option.description}
+                                        </motion.p>
+                                    )}
                                 </AnimatePresence>
                             </div>
-                          </label>
-                        </div>
-                      ))}
-                      <div className="flex items-center justify-between w-full p-3">
-                          <div className="flex flex-col">
-                              <span className="text-md font-semibold leading-none text-gray-900 dark:text-gray-100">DAG Mode</span>
-                              <span className="text-sm text-gray-700 dark:text-gray-300 mt-1">Display as a directed acyclic graph.</span>
-                          </div>
-                          <Switch checked={dagMode} onCheckedChange={setDagMode} />
-                      </div>
-                  </RadioGroup>
-            </PopoverContent>
-              </div>
-        </Popover>
+                        </label>
+                    </div>
+                ))}
+                <div className="flex items-center justify-between w-full p-3">
+                    <div className="flex flex-col">
+                        <span className="text-md font-semibold leading-none text-gray-900 dark:text-gray-100">DAG Mode</span>
+                        <span className="text-sm text-gray-700 dark:text-gray-300 mt-1">Display as a directed acyclic graph.</span>
+                    </div>
+                    <Switch checked={dagMode} onCheckedChange={setDagMode} />
+                </div>
+            </RadioGroup>
+        </ResponsivePanel>
     )
 }

--- a/src/components/ClusteringPanel.tsx
+++ b/src/components/ClusteringPanel.tsx
@@ -41,8 +41,8 @@ export default function ClusteringPanel({ clusterMode, setClusterMode, dagMode, 
                   <RadioGroup
                     value={clusterMode}
                     onValueChange={(value) => setClusterMode(value as GenreClusterMode)}
-                    className="flex flex-col items-start w-full gap-1 dark:bg-background shadow-xs p-2 rounded-xl border border-accent dark:border-border/50
-          bg-gray-50"
+                    className="flex flex-col items-start w-full gap-1 dark:bg-background shadow-sm p-2 rounded-2xl border border-accent dark:border-border/50
+          bg-accent"
                   >
                       {options.map((option) => (
                         <div key={option.id} className="w-full">

--- a/src/components/ClusteringPanel.tsx
+++ b/src/components/ClusteringPanel.tsx
@@ -37,7 +37,7 @@ export default function ClusteringPanel({ clusterMode, setClusterMode, dagMode, 
                   <Spline />
                 </Button>
              </PopoverTrigger>
-            <PopoverContent side="left" align="start" sideOffset= {4} className="w-full max-w-md">
+            <PopoverContent side="left" align="start" className="w-full max-w-md">
                   <RadioGroup
                     value={clusterMode}
                     onValueChange={(value) => setClusterMode(value as GenreClusterMode)}

--- a/src/components/DisplayPanel.tsx
+++ b/src/components/DisplayPanel.tsx
@@ -24,7 +24,7 @@ export default function DisplayPanel() {
             }
             className="w-sm"
         >
-            <div className="flex flex-col gap-4 p-2 rounded-xl border border-accent shadow-sm bg-accent dark:dark:bg-background">
+            <div className="flex flex-col gap-4 p-2 rounded-2xl border border-accent shadow-sm bg-accent dark:dark:bg-background">
                 {/* Node Size */}
                 <div className="flex items-center justify-start gap-6">
                     <label htmlFor="node-size" className="w-full text-left text-md font-medium text-gray-900 dark:text-gray-100">Node Size</label>

--- a/src/components/DisplayPanel.tsx
+++ b/src/components/DisplayPanel.tsx
@@ -24,7 +24,10 @@ export default function DisplayPanel() {
           </Button>
         </PopoverTrigger>
         <PopoverContent side="left" className="w-sm">
-          <div className="flex flex-col gap-4 p-2">
+          <div className="flex flex-col gap-4 p-2
+          rounded-xl border border-accent shadow-sm 
+          bg-accent dark:dark:bg-background"
+          >
             {/* Node Size */}
             <div className="flex items-center justify-start gap-6">
               <label htmlFor="node-size" className="w-full text-left

--- a/src/components/DisplayPanel.tsx
+++ b/src/components/DisplayPanel.tsx
@@ -2,10 +2,9 @@ import { useState } from "react"
 import { Slider } from "@/components/ui/slider"
 import { Switch } from "@/components/ui/switch"
 import { Badge } from "./ui/badge"
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Button } from "@/components/ui/button"
 import { SwatchBook } from "lucide-react"
-
+import { ResponsivePanel } from "@/components/ResponsivePanel"
 
 export default function DisplayPanel() {
     const [nodeSize, setNodeSize] = useState(50)
@@ -16,101 +15,95 @@ export default function DisplayPanel() {
     const [showUnfollowedArtists, setShowUnfollowedArtists] = useState(false)
 
     return (
-      <Popover>
-        <PopoverTrigger asChild>
-          <Button variant="outline" size="icon" className="h-10 w-10">
-            <SwatchBook className="h-[1.2rem] w-[1.2rem]" />
-            <span className="sr-only">Display Settings</span>
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent side="left" className="w-sm">
-          <div className="flex flex-col gap-4 p-2
-          rounded-xl border border-accent shadow-sm 
-          bg-accent dark:dark:bg-background"
-          >
-            {/* Node Size */}
-            <div className="flex items-center justify-start gap-6">
-              <label htmlFor="node-size" className="w-full text-left
-    text-md font-medium text-gray-900 dark:text-gray-100">Node Size</label>
-              <div className="w-full flex items-center gap-2">
-                <Badge variant="outline" className="w-12 p-1 text-center">{nodeSize}</Badge>      
-                <Slider
-                  id="node-size-slider"
-                  aria-labelledby="node-size"
-                  value={[nodeSize]}
-                  onValueChange={([value]) => setNodeSize(value)}
-                  min={0}
-                  max={100}
-                  step={1}
-                  className="w-full"
-                />
-              </div>
+        <ResponsivePanel
+            trigger={
+                <Button variant="outline" size="icon" className="h-10 w-10">
+                    <SwatchBook className="h-[1.2rem] w-[1.2rem]" />
+                    <span className="sr-only">Display Settings</span>
+                </Button>
+            }
+            className="w-sm"
+        >
+            <div className="flex flex-col gap-4 p-2 rounded-xl border border-accent shadow-sm bg-accent dark:dark:bg-background">
+                {/* Node Size */}
+                <div className="flex items-center justify-start gap-6">
+                    <label htmlFor="node-size" className="w-full text-left text-md font-medium text-gray-900 dark:text-gray-100">Node Size</label>
+                    <div className="w-full flex items-center gap-2">
+                        <Badge variant="outline" className="w-12 p-1 text-center">{nodeSize}</Badge>
+                        <Slider
+                            id="node-size-slider"
+                            aria-labelledby="node-size"
+                            value={[nodeSize]}
+                            onValueChange={([value]) => setNodeSize(value)}
+                            min={0}
+                            max={100}
+                            step={1}
+                            className="w-full"
+                        />
+                    </div>
+                </div>
+                {/* Edge Thickness */}
+                <div className="flex items-center justify-start gap-6">
+                    <label htmlFor="edge-thickness" className="w-full text-left text-md font-medium text-gray-900 dark:text-gray-100">Edge thickness</label>
+                    <div className="w-full flex items-center gap-2">
+                        <Badge variant="outline" className="w-12 p-1 text-center">{edgeThickness}</Badge>
+                        <Slider
+                            id="edge-thickness-slider"
+                            aria-labelledby="edge-thickness"
+                            value={[edgeThickness]}
+                            onValueChange={([value]) => setEdgeThickness(value)}
+                            min={0}
+                            max={100}
+                            step={1}
+                            className="w-full"
+                        />
+                    </div>
+                </div>
+                {/* Text Fade Threshold */}
+                <div className="flex items-center justify-start gap-6">
+                    <label htmlFor="text-fade-threshold" className="w-full text-left text-md font-medium text-gray-900 dark:text-gray-100">Text Fade Threshold</label>
+                    <div className="w-full flex items-center gap-2">
+                        <Badge variant="outline" className="w-12 p-1 text-center">{textFadeThreshold}</Badge>
+                        <Slider
+                            id="text-fade-threshold-slider"
+                            aria-labelledby="text-fade-threshold"
+                            value={[textFadeThreshold]}
+                            onValueChange={([value]) => setTextFadeThreshold(value)}
+                            min={0}
+                            max={100}
+                            step={1}
+                            className="w-full"
+                        />
+                    </div>
+                </div>
+                <fieldset className="flex flex-col gap-4">
+                    <legend className="sr-only">Display options</legend>
+                    <div className="flex items-center justify-between">
+                        <label htmlFor="show-labels" className="w-full text-left text-md font-medium text-gray-900 dark:text-gray-100">Show labels</label>
+                        <Switch
+                            id="show-labels"
+                            checked={showLabels}
+                            onCheckedChange={setShowLabels}
+                        />
+                    </div>
+                    <div className="flex items-center justify-between">
+                        <label htmlFor="show-artist-image" className="w-full text-left text-md font-medium text-gray-900 dark:text-gray-100">Show artist image</label>
+                        <Switch
+                            id="show-artist-image"
+                            checked={showArtistImage}
+                            onCheckedChange={setShowArtistImage}
+                        />
+                    </div>
+                    <div className="flex items-center justify-between">
+                        <label htmlFor="show-unfollowed-artists" className="w-full text-left text-md font-medium text-gray-900 dark:text-gray-100">Show unfollowed artists</label>
+                        <Switch
+                            id="show-unfollowed-artists"
+                            checked={showUnfollowedArtists}
+                            onCheckedChange={setShowUnfollowedArtists}
+                        />
+                    </div>
+                </fieldset>
             </div>
-            {/* Edge Thickness */}
-            <div className="flex items-center justify-start gap-6">
-              <label htmlFor="edge-thickness" className="w-full text-left text-md font-medium text-gray-900 dark:text-gray-100">Edge thickness</label>
-              <div className="w-full flex items-center gap-2">
-              <Badge variant="outline" className="w-12 p-1 text-center">{edgeThickness}</Badge>      
-
-                <Slider
-                  id="edge-thickness-slider"
-                  aria-labelledby="edge-thickness"
-                  value={[edgeThickness]}
-                  onValueChange={([value]) => setEdgeThickness(value)}
-                  min={0}
-                  max={100}
-                  step={1}
-                  className="w-full"
-                />
-              </div>
-            </div>
-            {/* Text Fade Threshold */}
-            <div className="flex items-center justify-start gap-6">
-              <label htmlFor="text-fade-threshold" className="w-full text-left text-md font-medium text-gray-900 dark:text-gray-100">Text Fade Threshold</label>
-              <div className="w-full flex items-center gap-2">
-              <Badge variant="outline" className="w-12 p-1 text-center">{textFadeThreshold}</Badge>      
-
-                <Slider
-                  id="text-fade-threshold-slider"
-                  aria-labelledby="text-fade-threshold"
-                  value={[textFadeThreshold]}
-                  onValueChange={([value]) => setTextFadeThreshold(value)}
-                  min={0}
-                  max={100}
-                  step={1}
-                  className="w-full"
-                />
-              </div>
-            </div>
-            <fieldset className="flex flex-col gap-4">
-              <legend className="sr-only">Display options</legend>
-              <div className="flex items-center justify-between">
-                <label htmlFor="show-labels" className="w-full text-left text-md font-medium text-gray-900 dark:text-gray-100">Show labels</label>
-                <Switch
-                  id="show-labels"
-                  checked={showLabels}
-                  onCheckedChange={setShowLabels}
-                />
-              </div>
-              <div className="flex items-center justify-between">
-                <label htmlFor="show-artist-image" className="w-full text-left text-md font-medium text-gray-900 dark:text-gray-100">Show artist image</label>
-                <Switch
-                  id="show-artist-image"
-                  checked={showArtistImage}
-                  onCheckedChange={setShowArtistImage}
-                />
-              </div>
-              <div className="flex items-center justify-between">
-                <label htmlFor="show-unfollowed-artists" className="w-full text-left text-md font-medium text-gray-900 dark:text-gray-100">Show unfollowed artists</label>
-                <Switch
-                  id="show-unfollowed-artists"
-                  checked={showUnfollowedArtists}
-                  onCheckedChange={setShowUnfollowedArtists}
-                />
-              </div>
-            </fieldset>
-          </div>
-        </PopoverContent>
-      </Popover>
+        </ResponsivePanel>
     )
 }

--- a/src/components/GenrePanel.tsx
+++ b/src/components/GenrePanel.tsx
@@ -21,7 +21,7 @@ export default function GenrePanel({
           <span className="sr-only">Display Settings</span>
         </Button>
       }
-      className="w-sm p-2 overflow-hidden"
+      className="p-2 overflow-hidden"
     >
       {/* scrolling container */}
       <div className="overflow-y-auto max-h-120 rounded-xl border border-accent shadow-sm bg-accent dark:dark:bg-background">

--- a/src/components/GenrePanel.tsx
+++ b/src/components/GenrePanel.tsx
@@ -30,7 +30,7 @@ export default function GenrePanel({
       <PopoverContent
         side="left"
         align="start"
-        className="w-72 p-2 overflow-hidden"
+        className="w-sm p-2 overflow-hidden"
       >
         {/* scrolling container */}
         <div className="overflow-y-auto max-h-120 rounded-xl border border-accent shadow-sm bg-accent dark:dark:bg-background">

--- a/src/components/GenrePanel.tsx
+++ b/src/components/GenrePanel.tsx
@@ -1,15 +1,38 @@
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { Tag } from "lucide-react";
 import useGenres from "@/hooks/useGenres";
-import {Genre, GenreClusterMode} from "@/types";
+import { Genre, GenreClusterMode } from "@/types";
 import { isParentGenre } from "@/lib/utils";
 
+/**
+ * If you already export `clusterColors` from "@/lib/utils", keep the import.
+ * Otherwise, define it locally as shown below. (Remove whichever version you don't need.)
+ */
+// import { clusterColors } from "@/lib/utils";
+const clusterColors = [
+  "#FFB6C1",
+  "#87CEFA",
+  "#90EE90",
+  "#FFD700",
+  "#FFA07A",
+  "#20B2AA",
+  "#9370DB",
+];
 
-export default function GenrePanel({genres, genreClusterMode}: {genres: Genre[], genreClusterMode: GenreClusterMode}) {
-
+export default function GenrePanel({
+  genres,
+  genreClusterMode,
+}: {
+  genres: Genre[];
+  genreClusterMode: GenreClusterMode;
+}) {
   return (
     <Popover>
       <PopoverTrigger asChild>
@@ -25,24 +48,43 @@ export default function GenrePanel({genres, genreClusterMode}: {genres: Genre[],
         className="w-72 p-2 overflow-hidden"
       >
         {/* scrolling container */}
-          {/* <h3 className="text-md px-3 py-2 text-accent-foreground font-semibold ">Genre clusters</h3> */}
-          {/* content */}
-        <div className="overflow-y-auto max-h-120 rounded-xl border border-accent shadow-sm 
-          bg-accent dark:dark:bg-background">
-          <div className="
-          flex flex-col gap-0.5 py-2 pl-4 ">
-            {genres.filter(genre => isParentGenre(genre, genreClusterMode)).map(((genre: Genre) => (
-                  <Label htmlFor={genre.id} className="text-md text-foreground flex items-center py-2 cursor-pointer">
-                  <Checkbox defaultChecked
-                  id={genre.id}/>
-                  {genre.name}
-                  </Label>
+        <div className="overflow-y-auto max-h-120 rounded-xl border border-accent shadow-sm bg-accent dark:dark:bg-background">
+          <div className="flex flex-col gap-0.5 py-2 pl-4 pr-2">
+            {genres
+              .filter((genre) => isParentGenre(genre, genreClusterMode))
+              .map((genre: Genre, index: number) => (
+                <Label
+                  key={genre.id}
+                  htmlFor={genre.id}
+                  className="text-md text-foreground flex items-center gap-2 py-2 cursor-pointer"
+                >
+                  {/* TODO: Add click handler to toggle visibility of genre/cluster */}
+                  <Checkbox defaultChecked id={genre.id} />
 
-            )))}
+                  {/* colored dot */}
+
+                  <span className="w-full">{genre.name}</span>
+                  <Button 
+                  variant="ghost"
+                  className="p-2"
+                  // TODO: Add click handler to change cluster/genre color
+                  >
+                    <span
+                      className="
+                      p-2 w-4 h-4 shrink-0
+                      rounded-full inline-block"
+                      style={{
+                        backgroundColor:
+                          clusterColors[index % clusterColors.length],
+                      }}
+                    />
+                  </Button>
+                </Label>
+              ))}
           </div>
-           {/* overflow gradient */}
+          {/* overflow gradient */}
         </div>
-      <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-10 bg-gradient-to-t from-white to-transparent dark:from-black/27" />
+        <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-10 bg-gradient-to-t from-white to-transparent dark:from-black/27" />
       </PopoverContent>
     </Popover>
   );

--- a/src/components/GenrePanel.tsx
+++ b/src/components/GenrePanel.tsx
@@ -24,7 +24,7 @@ export default function GenrePanel({
       className="p-2 overflow-hidden"
     >
       {/* scrolling container */}
-      <div className="overflow-y-auto max-h-120 rounded-xl border border-accent shadow-sm bg-accent dark:dark:bg-background">
+      <div className="overflow-y-auto max-h-120 rounded-2xl border border-accent shadow-sm bg-accent dark:dark:bg-background">
         <div className="flex flex-col gap-0.5 py-2 pl-4 pr-2">
           {genres
             .filter((genre) => isParentGenre(genre, genreClusterMode))

--- a/src/components/GenrePanel.tsx
+++ b/src/components/GenrePanel.tsx
@@ -1,15 +1,10 @@
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { Tag } from "lucide-react";
 import { Genre, GenreClusterMode } from "@/types";
-import { isParentGenre } from "@/lib/utils";
-import { clusterColors } from "@/lib/utils";
+import { clusterColors, isParentGenre } from "@/lib/utils";
+import { ResponsivePanel } from "@/components/ResponsivePanel";
 
 export default function GenrePanel({
   genres,
@@ -19,58 +14,53 @@ export default function GenrePanel({
   genreClusterMode: GenreClusterMode;
 }) {
   return (
-    <Popover>
-      <PopoverTrigger asChild>
+    <ResponsivePanel
+      trigger={
         <Button variant="outline" size="icon" className="h-10 w-10">
           <Tag className="h-[1.2rem] w-[1.2rem]" />
           <span className="sr-only">Display Settings</span>
         </Button>
-      </PopoverTrigger>
+      }
+      className="w-sm p-2 overflow-hidden"
+    >
+      {/* scrolling container */}
+      <div className="overflow-y-auto max-h-120 rounded-xl border border-accent shadow-sm bg-accent dark:dark:bg-background">
+        <div className="flex flex-col gap-0.5 py-2 pl-4 pr-2">
+          {genres
+            .filter((genre) => isParentGenre(genre, genreClusterMode))
+            .map((genre: Genre, index: number) => (
+              <Label
+                key={genre.id}
+                htmlFor={genre.id}
+                className="text-md text-foreground flex items-center gap-2 py-2 cursor-pointer"
+              >
+                {/* TODO: Add click handler to toggle visibility of genre/cluster */}
+                <Checkbox defaultChecked id={genre.id} />
 
-      <PopoverContent
-        side="left"
-        align="start"
-        className="w-sm p-2 overflow-hidden"
-      >
-        {/* scrolling container */}
-        <div className="overflow-y-auto max-h-120 rounded-xl border border-accent shadow-sm bg-accent dark:dark:bg-background">
-          <div className="flex flex-col gap-0.5 py-2 pl-4 pr-2">
-            {genres
-              .filter((genre) => isParentGenre(genre, genreClusterMode))
-              .map((genre: Genre, index: number) => (
-                <Label
-                  key={genre.id}
-                  htmlFor={genre.id}
-                  className="text-md text-foreground flex items-center gap-2 py-2 cursor-pointer"
-                >
-                  {/* TODO: Add click handler to toggle visibility of genre/cluster */}
-                  <Checkbox defaultChecked id={genre.id} />
+                {/* colored dot */}
 
-                  {/* colored dot */}
-
-                  <span className="w-full">{genre.name}</span>
-                  <Button 
+                <span className="w-full">{genre.name}</span>
+                <Button
                   variant="ghost"
                   className="p-2"
                   // TODO: Add click handler to change cluster/genre color
-                  >
-                    <span
-                      className="
+                >
+                  <span
+                    className="
                       p-2 w-4 h-4 shrink-0
                       rounded-full inline-block"
-                      style={{
-                        backgroundColor:
-                          clusterColors[index % clusterColors.length],
-                      }}
-                    />
-                  </Button>
-                </Label>
-              ))}
-          </div>
-          {/* overflow gradient */}
+                    style={{
+                      backgroundColor:
+                        clusterColors[index % clusterColors.length],
+                    }}
+                  />
+                </Button>
+              </Label>
+            ))}
         </div>
-        <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-10 bg-gradient-to-t from-white to-transparent dark:from-black/27" />
-      </PopoverContent>
-    </Popover>
+        {/* overflow gradient */}
+      </div>
+      <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-10 bg-gradient-to-t from-white to-transparent dark:from-black/27" />
+    </ResponsivePanel>
   );
 }

--- a/src/components/GenrePanel.tsx
+++ b/src/components/GenrePanel.tsx
@@ -1,33 +1,49 @@
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
-import { Button } from "@/components/ui/button"
-import { Tag } from "lucide-react"
-import { Genre, NodeLink } from "@/types";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Button } from "@/components/ui/button";
+import { Tag } from "lucide-react";
+import useGenres from "@/hooks/useGenres";
+import { GraphType } from "@/types";     // remove if not needed
+import { Genre } from "@/types";         // keeps Genre for local typings
 
-interface GenrePanelProps {
-  genres: Genre[];
-}
+// If the component should be controlled from the parent, keep the prop.
+// Otherwise, delete the prop and rely entirely on the hook. Here we delete it.
+export default function GenrePanel() {
+  // Fetch genres once the component mounts
+  const { genres, genresLoading, genresError } = useGenres();
 
-export default function GenrePanel({ genres }: GenrePanelProps) {
-    genres.map((genre) => (
-        <div key={genre.name} className="flex items-center justify-between p-2 border-b border-gray-200">
+  // Optional: show a loader / error message
+  if (genresLoading) return <p>Loading genres…</p>;
+  if (genresError)   return <p>Failed to load genres.</p>;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline" size="icon" className="h-10 w-10">
+          <Tag className="h-[1.2rem] w-[1.2rem]" />
+          <span className="sr-only">Display Settings</span>
+        </Button>
+      </PopoverTrigger>
+
+      <PopoverContent
+        side="left"
+        align="start"
+        className="w-72 p-4 bg-white border border-gray-200 rounded-xl shadow-md"
+      >
+        {/* List the genres */}
+        {genres.map((genre: Genre) => (
+          <div
+            key={genre.name}
+            className="flex items-center justify-between p-2 border-b border-gray-200"
+          >
             <span className="text-sm font-medium">{genre.name}</span>
             <span className="text-xs text-gray-500">{genre.artistCount} artists</span>
-        </div>
-    ));
-    return (
-        // <div className="flex flex-col items-start w-full align-start h-10 gap-0.5 p-1 bg-gray-50 border border-gray-200 rounded-xl shadow-sm">
-        // </div>
-        <Popover>
-            <PopoverTrigger asChild>
-                <Button variant="outline" size="icon" className="h-10 w-10">
-            <Tag className="h-[1.2rem] w-[1.2rem]" />
-            <span className="sr-only">Display Settings</span>
-          </Button>
-            </PopoverTrigger>
-            <PopoverContent side="left" align="start" className="w-72 p-4 bg-white border border-gray-200 rounded-xl shadow-md">
-                {/* Content for the genre panel goes here */}
-                <p>Select a genre to explore its artists and links.</p>
-            </PopoverContent>
-        </Popover>
-    )
+          </div>
+        ))}
+
+        <p className="mt-2 text-sm text-gray-600">
+          Select a genre to explore its artists and links.
+        </p>
+      </PopoverContent>
+    </Popover>
+  );
 }

--- a/src/components/GenrePanel.tsx
+++ b/src/components/GenrePanel.tsx
@@ -27,8 +27,8 @@ export default function GenrePanel({genres, genreClusterMode}: {genres: Genre[],
         {/* scrolling container */}
           {/* <h3 className="text-md px-3 py-2 text-accent-foreground font-semibold ">Genre clusters</h3> */}
           {/* content */}
-        <div className="overflow-y-auto max-h-120 rounded-xl border border-accent shadow-xs 
-          bg-accent">
+        <div className="overflow-y-auto max-h-120 rounded-xl border border-accent shadow-sm 
+          bg-accent dark:dark:bg-background">
           <div className="
           flex flex-col gap-0.5 py-2 pl-4 ">
             {genres.filter(genre => isParentGenre(genre, genreClusterMode)).map(((genre: Genre) => (
@@ -42,7 +42,7 @@ export default function GenrePanel({genres, genreClusterMode}: {genres: Genre[],
           </div>
            {/* overflow gradient */}
         </div>
-      <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-10 bg-gradient-to-t from-white to-transparent dark:from-black/40" />
+      <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-10 bg-gradient-to-t from-white to-transparent dark:from-black/27" />
       </PopoverContent>
     </Popover>
   );

--- a/src/components/GenrePanel.tsx
+++ b/src/components/GenrePanel.tsx
@@ -5,6 +5,7 @@ import { Label } from "@/components/ui/label";
 import { Tag } from "lucide-react";
 import useGenres from "@/hooks/useGenres";
 import { Genre } from "@/types";
+import { isParentGenre } from "@/lib/utils";
 
 
 export default function GenrePanel() {
@@ -23,29 +24,33 @@ export default function GenrePanel() {
       <PopoverContent
         side="left"
         align="start"
-        className="w-72 p-4 bg-white border border-gray-200 rounded-xl shadow-md"
+        className="w-72 p-2"
       >
-        {genres.map((genre: Genre) => (
-
-            <div>
-                <Checkbox
-                    key={genre.id}
-                />
-                <Label htmlFor={genre.id} className="ml-2">{genre.name}</Label>
-            </div>
-
-        //   <div
-        //     key={genre.name}
-        //     className="flex items-center justify-between p-2 border-b border-gray-200"
-        //   >
-        //     <span className="text-sm font-medium">{genre.name}</span>
-        //     <span className="text-xs text-gray-500">{genre.artistCount} artists</span>
-        //   </div>
-        ))}
-
-        <p className="mt-2 text-sm text-gray-600">
-          Select a genre to explore its artists and links.
-        </p>
+        {/* scrolling container */}
+        <div className="overflow-y-auto max-h-120">
+          {/* content */}
+          <div className="
+          flex flex-col gap-0.5 py-2 pl-4 rounded-xl
+          bg-gray-50 border border-border">
+            {genres.map(((genre: Genre) => (
+                  <Label htmlFor={genre.id} className="flex items-center py-3 border-b cursor-pointer">
+                  <Checkbox defaultChecked 
+                  id={genre.id}/>
+                  {genre.name}
+                {/* <div key={genre.id} className="flex items-center py-2 cursor-pointer" > */}
+                  </Label>
+          
+                // </div>
+            //   <div
+            //     key={genre.name}
+            //     className="flex items-center justify-between p-2 border-b border-gray-200"
+            //   >
+            //     <span className="text-sm font-medium">{genre.name}</span>
+            //     <span className="text-xs text-gray-500">{genre.artistCount} artists</span>
+            //   </div>
+            )))}
+          </div>
+        </div>
       </PopoverContent>
     </Popover>
   );

--- a/src/components/GenrePanel.tsx
+++ b/src/components/GenrePanel.tsx
@@ -8,9 +8,7 @@ import { Genre } from "@/types";
 import { isParentGenre } from "@/lib/utils";
 
 
-export default function GenrePanel() {
-  // Fetch genres once the component mounts
-  const { genres, genresLoading, genresError } = useGenres();
+export default function GenrePanel({genres}: {genres: Genre[]}) {
 
   return (
     <Popover>
@@ -24,33 +22,27 @@ export default function GenrePanel() {
       <PopoverContent
         side="left"
         align="start"
-        className="w-72 p-2"
+        className="w-72 p-2 overflow-hidden"
       >
         {/* scrolling container */}
-        <div className="overflow-y-auto max-h-120">
+          {/* <h3 className="text-md px-3 py-2 text-accent-foreground font-semibold ">Genre clusters</h3> */}
           {/* content */}
+        <div className="overflow-y-auto max-h-120 rounded-xl border border-border dark:border-border/50
+          bg-gray-50">
           <div className="
-          flex flex-col gap-0.5 py-2 pl-4 rounded-xl
-          bg-gray-50 border border-border">
+          flex flex-col gap-0.5 py-2 pl-4 ">
             {genres.map(((genre: Genre) => (
-                  <Label htmlFor={genre.id} className="flex items-center py-3 border-b cursor-pointer">
+                  <Label htmlFor={genre.id} className="text-md text-foreground flex items-center py-2 cursor-pointer">
                   <Checkbox defaultChecked 
                   id={genre.id}/>
                   {genre.name}
-                {/* <div key={genre.id} className="flex items-center py-2 cursor-pointer" > */}
                   </Label>
-          
-                // </div>
-            //   <div
-            //     key={genre.name}
-            //     className="flex items-center justify-between p-2 border-b border-gray-200"
-            //   >
-            //     <span className="text-sm font-medium">{genre.name}</span>
-            //     <span className="text-xs text-gray-500">{genre.artistCount} artists</span>
-            //   </div>
+
             )))}
           </div>
+           {/* overflow gradient */}
         </div>
+      <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-10 bg-gradient-to-t from-white to-transparent" />
       </PopoverContent>
     </Popover>
   );

--- a/src/components/GenrePanel.tsx
+++ b/src/components/GenrePanel.tsx
@@ -60,7 +60,7 @@ export default function GenrePanel({
         </div>
         {/* overflow gradient */}
       </div>
-      <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-10 bg-gradient-to-t from-white to-transparent dark:from-black/27" />
+      <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-10 bg-gradient-to-t from-white/80 to-transparent dark:from-black/27" />
     </ResponsivePanel>
   );
 }

--- a/src/components/GenrePanel.tsx
+++ b/src/components/GenrePanel.tsx
@@ -27,8 +27,8 @@ export default function GenrePanel({genres, genreClusterMode}: {genres: Genre[],
         {/* scrolling container */}
           {/* <h3 className="text-md px-3 py-2 text-accent-foreground font-semibold ">Genre clusters</h3> */}
           {/* content */}
-        <div className="overflow-y-auto max-h-120 rounded-xl border border-border dark:border-border/50
-          bg-gray-50">
+        <div className="overflow-y-auto max-h-120 rounded-xl border border-accent shadow-xs 
+          bg-accent">
           <div className="
           flex flex-col gap-0.5 py-2 pl-4 ">
             {genres.filter(genre => isParentGenre(genre, genreClusterMode)).map(((genre: Genre) => (
@@ -42,7 +42,7 @@ export default function GenrePanel({genres, genreClusterMode}: {genres: Genre[],
           </div>
            {/* overflow gradient */}
         </div>
-      <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-10 bg-gradient-to-t from-white to-transparent" />
+      <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-10 bg-gradient-to-t from-white to-transparent dark:from-black/40" />
       </PopoverContent>
     </Popover>
   );

--- a/src/components/GenrePanel.tsx
+++ b/src/components/GenrePanel.tsx
@@ -1,19 +1,15 @@
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
 import { Tag } from "lucide-react";
 import useGenres from "@/hooks/useGenres";
-import { GraphType } from "@/types";     // remove if not needed
-import { Genre } from "@/types";         // keeps Genre for local typings
+import { Genre } from "@/types";
 
-// If the component should be controlled from the parent, keep the prop.
-// Otherwise, delete the prop and rely entirely on the hook. Here we delete it.
+
 export default function GenrePanel() {
   // Fetch genres once the component mounts
   const { genres, genresLoading, genresError } = useGenres();
-
-  // Optional: show a loader / error message
-  if (genresLoading) return <p>Loading genres…</p>;
-  if (genresError)   return <p>Failed to load genres.</p>;
 
   return (
     <Popover>
@@ -29,15 +25,22 @@ export default function GenrePanel() {
         align="start"
         className="w-72 p-4 bg-white border border-gray-200 rounded-xl shadow-md"
       >
-        {/* List the genres */}
         {genres.map((genre: Genre) => (
-          <div
-            key={genre.name}
-            className="flex items-center justify-between p-2 border-b border-gray-200"
-          >
-            <span className="text-sm font-medium">{genre.name}</span>
-            <span className="text-xs text-gray-500">{genre.artistCount} artists</span>
-          </div>
+
+            <div>
+                <Checkbox
+                    key={genre.id}
+                />
+                <Label htmlFor={genre.id} className="ml-2">{genre.name}</Label>
+            </div>
+
+        //   <div
+        //     key={genre.name}
+        //     className="flex items-center justify-between p-2 border-b border-gray-200"
+        //   >
+        //     <span className="text-sm font-medium">{genre.name}</span>
+        //     <span className="text-xs text-gray-500">{genre.artistCount} artists</span>
+        //   </div>
         ))}
 
         <p className="mt-2 text-sm text-gray-600">

--- a/src/components/GenrePanel.tsx
+++ b/src/components/GenrePanel.tsx
@@ -1,9 +1,33 @@
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { Button } from "@/components/ui/button"
+import { Tag } from "lucide-react"
+import { Genre, NodeLink } from "@/types";
 
+interface GenrePanelProps {
+  genres: Genre[];
+}
 
-export default function GenrePanel() {
-    
-    return (
-        <div className="flex flex-col items-start w-full align-start h-10 gap-0.5 p-1 bg-gray-50 border border-gray-200 rounded-xl shadow-sm">
+export default function GenrePanel({ genres }: GenrePanelProps) {
+    genres.map((genre) => (
+        <div key={genre.name} className="flex items-center justify-between p-2 border-b border-gray-200">
+            <span className="text-sm font-medium">{genre.name}</span>
+            <span className="text-xs text-gray-500">{genre.artistCount} artists</span>
         </div>
+    ));
+    return (
+        // <div className="flex flex-col items-start w-full align-start h-10 gap-0.5 p-1 bg-gray-50 border border-gray-200 rounded-xl shadow-sm">
+        // </div>
+        <Popover>
+            <PopoverTrigger asChild>
+                <Button variant="outline" size="icon" className="h-10 w-10">
+            <Tag className="h-[1.2rem] w-[1.2rem]" />
+            <span className="sr-only">Display Settings</span>
+          </Button>
+            </PopoverTrigger>
+            <PopoverContent side="left" align="start" className="w-72 p-4 bg-white border border-gray-200 rounded-xl shadow-md">
+                {/* Content for the genre panel goes here */}
+                <p>Select a genre to explore its artists and links.</p>
+            </PopoverContent>
+        </Popover>
     )
 }

--- a/src/components/GenrePanel.tsx
+++ b/src/components/GenrePanel.tsx
@@ -7,24 +7,9 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { Tag } from "lucide-react";
-import useGenres from "@/hooks/useGenres";
 import { Genre, GenreClusterMode } from "@/types";
 import { isParentGenre } from "@/lib/utils";
-
-/**
- * If you already export `clusterColors` from "@/lib/utils", keep the import.
- * Otherwise, define it locally as shown below. (Remove whichever version you don't need.)
- */
-// import { clusterColors } from "@/lib/utils";
-const clusterColors = [
-  "#FFB6C1",
-  "#87CEFA",
-  "#90EE90",
-  "#FFD700",
-  "#FFA07A",
-  "#20B2AA",
-  "#9370DB",
-];
+import { clusterColors } from "@/lib/utils";
 
 export default function GenrePanel({
   genres,

--- a/src/components/GenrePanel.tsx
+++ b/src/components/GenrePanel.tsx
@@ -4,11 +4,11 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { Tag } from "lucide-react";
 import useGenres from "@/hooks/useGenres";
-import { Genre } from "@/types";
+import {Genre, GenreClusterMode} from "@/types";
 import { isParentGenre } from "@/lib/utils";
 
 
-export default function GenrePanel({genres}: {genres: Genre[]}) {
+export default function GenrePanel({genres, genreClusterMode}: {genres: Genre[], genreClusterMode: GenreClusterMode}) {
 
   return (
     <Popover>
@@ -31,9 +31,9 @@ export default function GenrePanel({genres}: {genres: Genre[]}) {
           bg-gray-50">
           <div className="
           flex flex-col gap-0.5 py-2 pl-4 ">
-            {genres.map(((genre: Genre) => (
+            {genres.filter(genre => isParentGenre(genre, genreClusterMode)).map(((genre: Genre) => (
                   <Label htmlFor={genre.id} className="text-md text-foreground flex items-center py-2 cursor-pointer">
-                  <Checkbox defaultChecked 
+                  <Checkbox defaultChecked
                   id={genre.id}/>
                   {genre.name}
                   </Label>

--- a/src/components/GraphControls.tsx
+++ b/src/components/GraphControls.tsx
@@ -134,7 +134,7 @@ export function GraphControls() {
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -10 }}
             >
-              <GenrePanel />
+              {/* <GenrePanel /> */}
             </motion.div>
           )}
         </AnimatePresence>

--- a/src/components/ResetButton.tsx
+++ b/src/components/ResetButton.tsx
@@ -13,21 +13,7 @@ export function ResetButton({ onClick, show }: ResetButtonProps) {
 
   const isMobile = useMediaQuery({ maxWidth: 640 }); // pass this in as a prop if you want to use it
   const [isLayoutAnimating, setIsLayoutAnimating] = useState(false);
-  const handleKeyDown = useCallback(
-    (event: KeyboardEvent) => {
-      if (event.metaKey && event.key === "ArrowLeft") {
-        onClick();
-      }
-    },
-    [onClick]
-  );
-
-  useEffect(() => {
-    window.addEventListener("keydown", handleKeyDown);
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [handleKeyDown]);
+  
 
   return show && (
       <motion.div 

--- a/src/components/ResetButton.tsx
+++ b/src/components/ResetButton.tsx
@@ -3,6 +3,7 @@ import { Undo2 } from "lucide-react";
 import { motion } from "framer-motion";
 import { useMediaQuery } from "react-responsive";
 import { useEffect, useCallback, useState } from "react";
+import { Badge } from "./ui/badge";
 
 interface ResetButtonProps {
     onClick: () => void;
@@ -28,11 +29,15 @@ export function ResetButton({ onClick, show }: ResetButtonProps) {
     >
         <Button
           className="rounded-full h-[54px] w-[54px] bg-stone-100/90 dark:bg-stone-900/50 backdrop-blur-xs border border-input shadow-lg"
-          size="icon"
           variant="secondary"
           onClick={onClick}
         >
           <Undo2 />
+          {/* <Badge
+                          className="text-xs text-muted-foreground"
+                          variant="outline"
+                          >ESC
+                          </Badge> */}
         </Button>
     </motion.div>
     )

--- a/src/components/ResponsivePanel.tsx
+++ b/src/components/ResponsivePanel.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import { useMediaQuery } from "@/hooks/use-media-query"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Drawer, DrawerContent, DrawerTrigger } from "@/components/ui/drawer"
+import { cn } from "@/lib/utils"
 
 interface ResponsivePanelProps {
   trigger: React.ReactNode
@@ -26,7 +27,7 @@ export function ResponsivePanel({ trigger, children, className }: ResponsivePane
   return (
     <Drawer>
       <DrawerTrigger asChild>{trigger}</DrawerTrigger>
-      <DrawerContent className="w-full dark:bg-background">
+      <DrawerContent className={cn("w-full")}>
         {children}
       </DrawerContent>
     </Drawer>

--- a/src/components/ResponsivePanel.tsx
+++ b/src/components/ResponsivePanel.tsx
@@ -1,0 +1,34 @@
+import * as React from "react"
+import { useMediaQuery } from "@/hooks/use-media-query"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { Drawer, DrawerContent, DrawerTrigger } from "@/components/ui/drawer"
+
+interface ResponsivePanelProps {
+  trigger: React.ReactNode
+  children: React.ReactNode
+  className?: string
+}
+
+export function ResponsivePanel({ trigger, children, className }: ResponsivePanelProps) {
+  const isDesktop = useMediaQuery("(min-width: 768px)")
+
+  if (isDesktop) {
+    return (
+      <Popover>
+        <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+        <PopoverContent side="left" align="start" className={className}>
+          {children}
+        </PopoverContent>
+      </Popover>
+    )
+  }
+
+  return (
+    <Drawer>
+      <DrawerTrigger asChild>{trigger}</DrawerTrigger>
+      <DrawerContent className="w-full dark:bg-background">
+        {children}
+      </DrawerContent>
+    </Drawer>
+  )
+}

--- a/src/components/ResponsivePanel.tsx
+++ b/src/components/ResponsivePanel.tsx
@@ -11,7 +11,7 @@ interface ResponsivePanelProps {
 }
 
 export function ResponsivePanel({ trigger, children, className }: ResponsivePanelProps) {
-  const isDesktop = useMediaQuery("(min-width: 768px)")
+  const isDesktop = useMediaQuery("(min-width: 640px)")
 
   if (isDesktop) {
     return (
@@ -27,7 +27,7 @@ export function ResponsivePanel({ trigger, children, className }: ResponsivePane
   return (
     <Drawer>
       <DrawerTrigger asChild>{trigger}</DrawerTrigger>
-      <DrawerContent className={cn("w-full")}>
+      <DrawerContent className={cn("")}>
         {children}
       </DrawerContent>
     </Drawer>

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -114,14 +114,16 @@ export function Search({ onGenreSelect, onArtistSelect, currentArtists, genres, 
             ) : selectedArtist ? (
               <span>{selectedArtist.name}</span>
             ) : (
-              <span>⌘K</span>
+              <div>
+                <span>Search</span>
+                          <Badge
+                          className="text-xs text-muted-foreground"
+                          variant="outline"
+                          >⌘K
+                          </Badge>
+              </div>
             )}
           </div>
-          {/* <Badge
-          className="text-xs text-muted-foreground"
-          variant="outline"
-          >⌘K
-          </Badge> */}
         </Button>
       </motion.div>
       <CommandDialog

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -101,8 +101,8 @@ export function Search({ onGenreSelect, onArtistSelect, currentArtists, genres }
         <Button
           variant="outline"
           aria-label="Search"
-          className=
-            {isMobile ? "w-full bg-background/90 hover:bg-accent/90 backdrop-blur-xs shadow-md rounded-full justify-between text-left text-md font-normal text-foreground h-[54px]" : "w- "}
+          className={`w-full bg-background/90 hover:bg-accent/90 backdrop-blur-xs shadow-md rounded-full justify-between text-left text-md font-normal text-foreground h-[54px]
+            ${isMobile ? "w-full" : ""}`}
           onClick={() => setOpen(true)}
         >
           <div className="flex gap-2 items-center">

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -107,7 +107,7 @@ export function Search({ onGenreSelect, onArtistSelect, currentArtists, genres, 
             ${isMobile ? "w-full" : ""}`}
           onClick={() => setOpen(true)}
         >
-          <div className="flex gap-2 items-center">
+          <div className="flex gap-2 items-center animate-fade-in">
             <SearchIcon size={20}></SearchIcon>
             {selectedGenre ? (
               <span className="">{selectedGenre.name}</span>

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -116,11 +116,12 @@ export function Search({ onGenreSelect, onArtistSelect, currentArtists, genres, 
             ) : (
               <div className="flex text-muted-foreground items-center gap-2">
                 <span>Search</span>
-                          <Badge
+                          {isMobile ? 
+                          "" : <Badge
                           className="text-xs text-muted-foreground"
                           variant="outline"
                           >⌘K
-                          </Badge>
+                          </Badge>}
               </div>
             )}
           </div>

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -12,6 +12,7 @@ import {Loading} from "@/components/Loading";
 import useMBArtistSearch from "@/hooks/useMBArtistSearch";
 import { cn } from "@/lib/utils"
 import { useTheme } from "next-themes"
+import { useMediaQuery } from "react-responsive";
 
 interface SearchProps {
   onGenreSelect: (genre: Genre) => void;
@@ -21,9 +22,11 @@ interface SearchProps {
   genres: Genre[];
 }
 
+
 const DEBOUNCE_MS = 500;
 
 export function Search({ onGenreSelect, onArtistSelect, currentArtists, genres }: SearchProps) {
+  const isMobile = useMediaQuery({ maxWidth: 640 });
   const [open, setOpen] = useState<boolean>(false);
   const [inputValue, setInputValue] = useState<string>("");
   const [query, setQuery] = useState("");
@@ -99,7 +102,7 @@ export function Search({ onGenreSelect, onArtistSelect, currentArtists, genres }
           variant="outline"
           aria-label="Search"
           className=
-            "w- h-[54px] bg-background/90 hover:bg-accent/90 backdrop-blur-xs shadow-md rounded-full justify-between text-left text-md font-normal text-foreground"
+            {isMobile ? "w-full bg-background/90 hover:bg-accent/90 backdrop-blur-xs shadow-md rounded-full justify-between text-left text-md font-normal text-foreground h-[54px]" : "w- "}
           onClick={() => setOpen(true)}
         >
           <div className="flex gap-2 items-center">

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -114,7 +114,7 @@ export function Search({ onGenreSelect, onArtistSelect, currentArtists, genres, 
             ) : selectedArtist ? (
               <span>{selectedArtist.name}</span>
             ) : (
-              <div>
+              <div className="flex text-muted-foreground items-center gap-2">
                 <span>Search</span>
                           <Badge
                           className="text-xs text-muted-foreground"

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -20,12 +20,14 @@ interface SearchProps {
   graphState: GraphType;
   currentArtists: Artist[];
   genres: Genre[];
+  selectedGenre?: Genre;
+  selectedArtist?: Artist;
 }
 
 
 const DEBOUNCE_MS = 500;
 
-export function Search({ onGenreSelect, onArtistSelect, currentArtists, genres }: SearchProps) {
+export function Search({ onGenreSelect, onArtistSelect, currentArtists, genres, selectedGenre, selectedArtist }: SearchProps) {
   const isMobile = useMediaQuery({ maxWidth: 640 });
   const [open, setOpen] = useState<boolean>(false);
   const [inputValue, setInputValue] = useState<string>("");
@@ -107,7 +109,13 @@ export function Search({ onGenreSelect, onArtistSelect, currentArtists, genres }
         >
           <div className="flex gap-2 items-center">
             <SearchIcon size={20}></SearchIcon>
-            <span className="text-sm text-foreground">⌘K</span>
+            {selectedGenre ? (
+              <span className="">{selectedGenre.name}</span>
+            ) : selectedArtist ? (
+              <span>{selectedArtist.name}</span>
+            ) : (
+              <span>⌘K</span>
+            )}
           </div>
           {/* <Badge
           className="text-xs text-muted-foreground"

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -14,7 +14,7 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+          "border backdrop-blur-sm bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
         secondary:
           "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
         ghost:

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { CheckIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="flex items-center justify-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -1,0 +1,133 @@
+import * as React from "react"
+import { Drawer as DrawerPrimitive } from "vaul"
+
+import { cn } from "@/lib/utils"
+
+function Drawer({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+}
+
+function DrawerTrigger({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+  return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />
+}
+
+function DrawerPortal({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+  return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />
+}
+
+function DrawerClose({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+  return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />
+}
+
+function DrawerOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+  return (
+    <DrawerPrimitive.Overlay
+      data-slot="drawer-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DrawerContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+  return (
+    <DrawerPortal data-slot="drawer-portal">
+      <DrawerOverlay />
+      <DrawerPrimitive.Content
+        data-slot="drawer-content"
+        className={cn(
+          "group/drawer-content bg-background fixed z-50 flex h-auto flex-col",
+          "data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b",
+          "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t",
+          "data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",
+          "data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:sm:max-w-sm",
+          className
+        )}
+        {...props}
+      >
+        <div className="bg-muted mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        {children}
+      </DrawerPrimitive.Content>
+    </DrawerPortal>
+  )
+}
+
+function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-header"
+      className={cn(
+        "flex flex-col gap-0.5 p-4 group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center group-data-[vaul-drawer-direction=top]/drawer-content:text-center md:gap-1.5 md:text-left",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function DrawerTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+  return (
+    <DrawerPrimitive.Title
+      data-slot="drawer-title"
+      className={cn("text-foreground font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DrawerDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+  return (
+    <DrawerPrimitive.Description
+      data-slot="drawer-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+}

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -54,16 +54,16 @@ function DrawerContent({
       <DrawerPrimitive.Content
         data-slot="drawer-content"
         className={cn(
-          "group/drawer-content bg-background fixed z-50 flex h-auto flex-col",
-          "data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b",
-          "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t",
+          "group/drawer-content fixed z-50 flex h-auto p-2 flex-col",
+          "data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg",
+          "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg",
           "data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",
-          "data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:sm:max-w-sm",
+          "data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-full data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:sm:max-w-sm",
           className
         )}
         {...props}
       >
-        <div className="bg-muted mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        <div className="bg-stone-300 mx-auto mt-2 mb-2 hidden h-1 w-[64px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
         {children}
       </DrawerPrimitive.Content>
     </DrawerPortal>

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -56,14 +56,16 @@ function DrawerContent({
         className={cn(
           "group/drawer-content pb-2 fixed z-50 flex h-auto px-2 flex-col bg-popover overflow-hidden border border-accent",
           "mx-2 data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg",
-          "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-6 data-[vaul-drawer-direction=bottom]:mt-2 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-3xl",
+          "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-2 data-[vaul-drawer-direction=bottom]:mt-2 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-3xl",
           "data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",
           "data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-full data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:sm:max-w-sm",
           className
         )}
         {...props}
       >
-        <div className="bg-stone-300 mx-auto mt-2 mb-2 hidden h-1 w-[64px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        <div>
+          <div className="bg-stone-300 mx-auto mt-2 mb-2 hidden h-1 w-[64px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        </div>
         {children}
       </DrawerPrimitive.Content>
     </DrawerPortal>

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -54,9 +54,9 @@ function DrawerContent({
       <DrawerPrimitive.Content
         data-slot="drawer-content"
         className={cn(
-          "group/drawer-content fixed z-50 flex h-auto p-2 flex-col",
-          "data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg",
-          "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg",
+          "group/drawer-content pb-2 fixed z-50 flex h-auto px-2 flex-col bg-popover overflow-hidden border border-accent",
+          "mx-2 data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg",
+          "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-6 data-[vaul-drawer-direction=bottom]:mt-2 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-3xl",
           "data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",
           "data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-full data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:sm:max-w-sm",
           className

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -11,7 +11,7 @@ function Label({
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        "text-foreground flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
         className
       )}
       {...props}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -18,7 +18,7 @@ function PopoverTrigger({
 function PopoverContent({
   className,
   align = "start",
-  sideOffset = 4,
+  sideOffset = 8,
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Content>) {
   return (

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import * as React from "react"
+import * as SeparatorPrimitive from "@radix-ui/react-separator"
+
+import { cn } from "@/lib/utils"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,137 @@
+import * as React from "react"
+import * as SheetPrimitive from "@radix-ui/react-dialog"
+import { XIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+function SheetPortal({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: "top" | "right" | "bottom" | "left"
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        data-slot="sheet-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          side === "right" &&
+            "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
+          side === "left" &&
+            "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
+          side === "top" &&
+            "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
+          side === "bottom" &&
+            "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+          <XIcon className="size-4" />
+          <span className="sr-only">Close</span>
+        </SheetPrimitive.Close>
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-1.5 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("text-foreground font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -1,0 +1,724 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, VariantProps } from "class-variance-authority"
+import { PanelLeftIcon } from "lucide-react"
+
+import { useIsMobile } from "@/hooks/use-mobile"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Separator } from "@/components/ui/separator"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+
+const SIDEBAR_COOKIE_NAME = "sidebar_state"
+const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
+const SIDEBAR_WIDTH = "16rem"
+const SIDEBAR_WIDTH_MOBILE = "18rem"
+const SIDEBAR_WIDTH_ICON = "3rem"
+const SIDEBAR_KEYBOARD_SHORTCUT = "b"
+
+type SidebarContextProps = {
+  state: "expanded" | "collapsed"
+  open: boolean
+  setOpen: (open: boolean) => void
+  openMobile: boolean
+  setOpenMobile: (open: boolean) => void
+  isMobile: boolean
+  toggleSidebar: () => void
+}
+
+const SidebarContext = React.createContext<SidebarContextProps | null>(null)
+
+function useSidebar() {
+  const context = React.useContext(SidebarContext)
+  if (!context) {
+    throw new Error("useSidebar must be used within a SidebarProvider.")
+  }
+
+  return context
+}
+
+function SidebarProvider({
+  defaultOpen = true,
+  open: openProp,
+  onOpenChange: setOpenProp,
+  className,
+  style,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  defaultOpen?: boolean
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+}) {
+  const isMobile = useIsMobile()
+  const [openMobile, setOpenMobile] = React.useState(false)
+
+  // This is the internal state of the sidebar.
+  // We use openProp and setOpenProp for control from outside the component.
+  const [_open, _setOpen] = React.useState(defaultOpen)
+  const open = openProp ?? _open
+  const setOpen = React.useCallback(
+    (value: boolean | ((value: boolean) => boolean)) => {
+      const openState = typeof value === "function" ? value(open) : value
+      if (setOpenProp) {
+        setOpenProp(openState)
+      } else {
+        _setOpen(openState)
+      }
+
+      // This sets the cookie to keep the sidebar state.
+      document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`
+    },
+    [setOpenProp, open]
+  )
+
+  // Helper to toggle the sidebar.
+  const toggleSidebar = React.useCallback(() => {
+    return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open)
+  }, [isMobile, setOpen, setOpenMobile])
+
+  // Adds a keyboard shortcut to toggle the sidebar.
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
+        (event.metaKey || event.ctrlKey)
+      ) {
+        event.preventDefault()
+        toggleSidebar()
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [toggleSidebar])
+
+  // We add a state so that we can do data-state="expanded" or "collapsed".
+  // This makes it easier to style the sidebar with Tailwind classes.
+  const state = open ? "expanded" : "collapsed"
+
+  const contextValue = React.useMemo<SidebarContextProps>(
+    () => ({
+      state,
+      open,
+      setOpen,
+      isMobile,
+      openMobile,
+      setOpenMobile,
+      toggleSidebar,
+    }),
+    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar]
+  )
+
+  return (
+    <SidebarContext.Provider value={contextValue}>
+      <TooltipProvider delayDuration={0}>
+        <div
+          data-slot="sidebar-wrapper"
+          style={
+            {
+              "--sidebar-width": SIDEBAR_WIDTH,
+              "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
+              ...style,
+            } as React.CSSProperties
+          }
+          className={cn(
+            "group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full",
+            className
+          )}
+          {...props}
+        >
+          {children}
+        </div>
+      </TooltipProvider>
+    </SidebarContext.Provider>
+  )
+}
+
+function Sidebar({
+  side = "left",
+  variant = "sidebar",
+  collapsible = "offcanvas",
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  side?: "left" | "right"
+  variant?: "sidebar" | "floating" | "inset"
+  collapsible?: "offcanvas" | "icon" | "none"
+}) {
+  const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
+
+  if (collapsible === "none") {
+    return (
+      <div
+        data-slot="sidebar"
+        className={cn(
+          "bg-sidebar text-sidebar-foreground flex h-full w-(--sidebar-width) flex-col",
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    )
+  }
+
+  if (isMobile) {
+    return (
+      <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
+        <SheetContent
+          data-sidebar="sidebar"
+          data-slot="sidebar"
+          data-mobile="true"
+          className="bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden"
+          style={
+            {
+              "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
+            } as React.CSSProperties
+          }
+          side={side}
+        >
+          <SheetHeader className="sr-only">
+            <SheetTitle>Sidebar</SheetTitle>
+            <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+          </SheetHeader>
+          <div className="flex h-full w-full flex-col">{children}</div>
+        </SheetContent>
+      </Sheet>
+    )
+  }
+
+  return (
+    <div
+      className="group peer text-sidebar-foreground hidden md:block"
+      data-state={state}
+      data-collapsible={state === "collapsed" ? collapsible : ""}
+      data-variant={variant}
+      data-side={side}
+      data-slot="sidebar"
+    >
+      {/* This is what handles the sidebar gap on desktop */}
+      <div
+        data-slot="sidebar-gap"
+        className={cn(
+          "relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
+          "group-data-[collapsible=offcanvas]:w-0",
+          "group-data-[side=right]:rotate-180",
+          variant === "floating" || variant === "inset"
+            ? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]"
+            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon)"
+        )}
+      />
+      <div
+        data-slot="sidebar-container"
+        className={cn(
+          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
+          side === "left"
+            ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
+            : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
+          // Adjust the padding for floating and inset variants.
+          variant === "floating" || variant === "inset"
+            ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
+            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l",
+          className
+        )}
+        {...props}
+      >
+        <div
+          data-sidebar="sidebar"
+          data-slot="sidebar-inner"
+          className="bg-sidebar group-data-[variant=floating]:border-sidebar-border flex h-full w-full flex-col group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:shadow-sm"
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SidebarTrigger({
+  className,
+  onClick,
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  const { toggleSidebar } = useSidebar()
+
+  return (
+    <Button
+      data-sidebar="trigger"
+      data-slot="sidebar-trigger"
+      variant="ghost"
+      size="icon"
+      className={cn("size-7", className)}
+      onClick={(event) => {
+        onClick?.(event)
+        toggleSidebar()
+      }}
+      {...props}
+    >
+      <PanelLeftIcon />
+      <span className="sr-only">Toggle Sidebar</span>
+    </Button>
+  )
+}
+
+function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
+  const { toggleSidebar } = useSidebar()
+
+  return (
+    <button
+      data-sidebar="rail"
+      data-slot="sidebar-rail"
+      aria-label="Toggle Sidebar"
+      tabIndex={-1}
+      onClick={toggleSidebar}
+      title="Toggle Sidebar"
+      className={cn(
+        "hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex",
+        "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
+        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+        "hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full",
+        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
+        "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
+  return (
+    <main
+      data-slot="sidebar-inset"
+      className={cn(
+        "bg-background relative flex w-full flex-1 flex-col",
+        "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof Input>) {
+  return (
+    <Input
+      data-slot="sidebar-input"
+      data-sidebar="input"
+      className={cn("bg-background h-8 w-full shadow-none", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-header"
+      data-sidebar="header"
+      className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-footer"
+      data-sidebar="footer"
+      className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="sidebar-separator"
+      data-sidebar="separator"
+      className={cn("bg-sidebar-border mx-2 w-auto", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-content"
+      data-sidebar="content"
+      className={cn(
+        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-group"
+      data-sidebar="group"
+      className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarGroupLabel({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"div"> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "div"
+
+  return (
+    <Comp
+      data-slot="sidebar-group-label"
+      data-sidebar="group-label"
+      className={cn(
+        "text-sidebar-foreground/70 ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarGroupAction({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "button"
+
+  return (
+    <Comp
+      data-slot="sidebar-group-action"
+      data-sidebar="group-action"
+      className={cn(
+        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        // Increases the hit area of the button on mobile.
+        "after:absolute after:-inset-2 md:after:hidden",
+        "group-data-[collapsible=icon]:hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarGroupContent({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-group-content"
+      data-sidebar="group-content"
+      className={cn("w-full text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenu({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="sidebar-menu"
+      data-sidebar="menu"
+      className={cn("flex w-full min-w-0 flex-col gap-1", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="sidebar-menu-item"
+      data-sidebar="menu-item"
+      className={cn("group/menu-item relative", className)}
+      {...props}
+    />
+  )
+}
+
+const sidebarMenuButtonVariants = cva(
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+        outline:
+          "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
+      },
+      size: {
+        default: "h-8 text-sm",
+        sm: "h-7 text-xs",
+        lg: "h-12 text-sm group-data-[collapsible=icon]:p-0!",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function SidebarMenuButton({
+  asChild = false,
+  isActive = false,
+  variant = "default",
+  size = "default",
+  tooltip,
+  className,
+  ...props
+}: React.ComponentProps<"button"> & {
+  asChild?: boolean
+  isActive?: boolean
+  tooltip?: string | React.ComponentProps<typeof TooltipContent>
+} & VariantProps<typeof sidebarMenuButtonVariants>) {
+  const Comp = asChild ? Slot : "button"
+  const { isMobile, state } = useSidebar()
+
+  const button = (
+    <Comp
+      data-slot="sidebar-menu-button"
+      data-sidebar="menu-button"
+      data-size={size}
+      data-active={isActive}
+      className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
+      {...props}
+    />
+  )
+
+  if (!tooltip) {
+    return button
+  }
+
+  if (typeof tooltip === "string") {
+    tooltip = {
+      children: tooltip,
+    }
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipContent
+        side="right"
+        align="center"
+        hidden={state !== "collapsed" || isMobile}
+        {...tooltip}
+      />
+    </Tooltip>
+  )
+}
+
+function SidebarMenuAction({
+  className,
+  asChild = false,
+  showOnHover = false,
+  ...props
+}: React.ComponentProps<"button"> & {
+  asChild?: boolean
+  showOnHover?: boolean
+}) {
+  const Comp = asChild ? Slot : "button"
+
+  return (
+    <Comp
+      data-slot="sidebar-menu-action"
+      data-sidebar="menu-action"
+      className={cn(
+        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        // Increases the hit area of the button on mobile.
+        "after:absolute after:-inset-2 md:after:hidden",
+        "peer-data-[size=sm]/menu-button:top-1",
+        "peer-data-[size=default]/menu-button:top-1.5",
+        "peer-data-[size=lg]/menu-button:top-2.5",
+        "group-data-[collapsible=icon]:hidden",
+        showOnHover &&
+          "peer-data-[active=true]/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 md:opacity-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuBadge({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-menu-badge"
+      data-sidebar="menu-badge"
+      className={cn(
+        "text-sidebar-foreground pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums select-none",
+        "peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground",
+        "peer-data-[size=sm]/menu-button:top-1",
+        "peer-data-[size=default]/menu-button:top-1.5",
+        "peer-data-[size=lg]/menu-button:top-2.5",
+        "group-data-[collapsible=icon]:hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuSkeleton({
+  className,
+  showIcon = false,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showIcon?: boolean
+}) {
+  // Random width between 50 to 90%.
+  const width = React.useMemo(() => {
+    return `${Math.floor(Math.random() * 40) + 50}%`
+  }, [])
+
+  return (
+    <div
+      data-slot="sidebar-menu-skeleton"
+      data-sidebar="menu-skeleton"
+      className={cn("flex h-8 items-center gap-2 rounded-md px-2", className)}
+      {...props}
+    >
+      {showIcon && (
+        <Skeleton
+          className="size-4 rounded-md"
+          data-sidebar="menu-skeleton-icon"
+        />
+      )}
+      <Skeleton
+        className="h-4 max-w-(--skeleton-width) flex-1"
+        data-sidebar="menu-skeleton-text"
+        style={
+          {
+            "--skeleton-width": width,
+          } as React.CSSProperties
+        }
+      />
+    </div>
+  )
+}
+
+function SidebarMenuSub({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="sidebar-menu-sub"
+      data-sidebar="menu-sub"
+      className={cn(
+        "border-sidebar-border mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l px-2.5 py-0.5",
+        "group-data-[collapsible=icon]:hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuSubItem({
+  className,
+  ...props
+}: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="sidebar-menu-sub-item"
+      data-sidebar="menu-sub-item"
+      className={cn("group/menu-sub-item relative", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuSubButton({
+  asChild = false,
+  size = "md",
+  isActive = false,
+  className,
+  ...props
+}: React.ComponentProps<"a"> & {
+  asChild?: boolean
+  size?: "sm" | "md"
+  isActive?: boolean
+}) {
+  const Comp = asChild ? Slot : "a"
+
+  return (
+    <Comp
+      data-slot="sidebar-menu-sub-button"
+      data-sidebar="menu-sub-button"
+      data-size={size}
+      data-active={isActive}
+      className={cn(
+        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-hidden focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+        "data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground",
+        size === "sm" && "text-xs",
+        size === "md" && "text-sm",
+        "group-data-[collapsible=icon]:hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupAction,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInput,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSkeleton,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarSeparator,
+  SidebarTrigger,
+  useSidebar,
+}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import * as React from "react"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return (
+    <TooltipProvider>
+      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+    </TooltipProvider>
+  )
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/src/hooks/use-media-query.ts
+++ b/src/hooks/use-media-query.ts
@@ -1,0 +1,19 @@
+import * as React from "react"
+ 
+export function useMediaQuery(query: string) {
+  const [value, setValue] = React.useState(false)
+ 
+  React.useEffect(() => {
+    function onChange(event: MediaQueryListEvent) {
+      setValue(event.matches)
+    }
+ 
+    const result = matchMedia(query)
+    result.addEventListener("change", onChange)
+    setValue(result.matches)
+ 
+    return () => result.removeEventListener("change", onChange)
+  }, [query])
+ 
+  return value
+}

--- a/src/hooks/use-mobile.ts
+++ b/src/hooks/use-mobile.ts
@@ -1,0 +1,19 @@
+import * as React from "react"
+
+const MOBILE_BREAKPOINT = 768
+
+export function useIsMobile() {
+  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+
+  React.useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+    const onChange = () => {
+      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    }
+    mql.addEventListener("change", onChange)
+    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    return () => mql.removeEventListener("change", onChange)
+  }, [])
+
+  return !!isMobile
+}

--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,7 @@
   color: rgba(255, 255, 255, 0.87);
   background-color: "bg-background";
 
+
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -189,6 +190,7 @@
 @layer base {
   * {
     @apply border-border outline-ring/50;
+    box-sizing: border-box;
   }
   body {
     @apply bg-background text-foreground;

--- a/src/index.css
+++ b/src/index.css
@@ -148,7 +148,7 @@
 
   --muted-foreground: oklch(0.708 0 0);
 
-  --accent: oklch(0.269 0 0);
+  --accent: oklch(0.269 0 0 );
 
   --accent-foreground: oklch(0.985 0 0);
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -98,3 +98,12 @@ export const buildGenreTree = (genres: Genre[], parent: Genre, mode: GenreCluste
   addChildren(parent.id, 1);
   return { nodes, links };
 };
+
+export const clusterColors = [
+  "#e06c75",
+  "#98c379",
+  "#d19a66",
+  "#56b6c2",
+  "#be5046",
+  "#a9a1e1",
+];


### PR DESCRIPTION
Introduces new "Genre Panel" feature and includes some general UI improvements

## Genre Panel
- Introduced a new GenrePanel component to display and interact with genres.
Implemented functionality to filter for parent genres.
- Added cluster colors to checkbox list items within the genre panel as a legend. 
- Integrated a clusterColors utility for consistent color management.
- Incorporated checkbox components for genre selection.
- Initial setup and development of the genre mapping logic.

## Responsive UI & Drawer Integration
- Created a ResponsivePanel component to manage switching between different popover and drawer based on mobile breakpoint
- Integrated the Drawer component from shadcn
- Adjusted drawer styling to appear floating 🤌

## Future Enhancements
- Hook up checkbox to hide/show parent genres and their clusters
- Apply unique colors to clusters
- Theming selection for cluster colors or color picker custom colors