### PR TITLE
Node limiter implementation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -253,10 +253,6 @@ function App() {
       return !!artists && !artistsLoading && !artistsError;
     } else return false;
   }
-  const onGraphTabSwitch = (graphType: GraphType) => {
-    setGraph(graphType);
-
-  }
 
   return (
     <SidebarProvider>

--- a/src/components/NodeLimiter.tsx
+++ b/src/components/NodeLimiter.tsx
@@ -9,15 +9,16 @@ import {
 import { Loading } from "./Loading"
 
 interface NodeLimiterProps {
-  initialValue?: number,
-  onChange: (value: number) => void
-  totalNodes?: number
-  nodeType?: string
+  initialValue: number;
+  onChange: (value: number) => void;
+  totalNodes: number;
+  nodeType: string;
+  show: boolean;
 }
 
-const ALL_PRESETS = [20000, 10000, 5000, 1000, 500, 200, 100, 50]
+const ALL_PRESETS = [20000, 10000, 5000, 2000, 1000, 500, 200, 100, 50]
 
-export default function NodeLimiter({ initialValue = 200, onChange, totalNodes, nodeType }: NodeLimiterProps) {
+export default function NodeLimiter({ initialValue, onChange, totalNodes, nodeType, show }: NodeLimiterProps) {
     const [value, setValue] = useState<number>(initialValue);
     const [presets, setPresets] = useState<number[]>(ALL_PRESETS);
     const onValueChange = (newValue: number) => {
@@ -31,7 +32,11 @@ export default function NodeLimiter({ initialValue = 200, onChange, totalNodes, 
         }
     }, [totalNodes]);
 
-    return (
+    useEffect(() => {
+        setValue(initialValue);
+    }, [initialValue]);
+
+    return show ? (
         <div
         className="
         flex gap-2 p-2 items-center
@@ -66,5 +71,5 @@ export default function NodeLimiter({ initialValue = 200, onChange, totalNodes, 
                 
                 <p className="text-muted-foreground">of {totalNodes} {nodeType}</p>
         </div>
-    )
+    ) : null;
 }

--- a/src/components/NodeLimiter.tsx
+++ b/src/components/NodeLimiter.tsx
@@ -10,17 +10,26 @@ import { Loading } from "./Loading"
 
 interface NodeLimiterProps {
   initialValue?: number,
-  onChange?: (value: number[]) => void
+  onChange: (value: number) => void
   totalNodes?: number
   nodeType?: string
 }
 
+const ALL_PRESETS = [20000, 10000, 5000, 1000, 500, 200, 100, 50]
+
 export default function NodeLimiter({ initialValue = 200, onChange, totalNodes, nodeType }: NodeLimiterProps) {
-    const [value, setValue] = useState<number[]>([200])
+    const [value, setValue] = useState<number>(initialValue);
+    const [presets, setPresets] = useState<number[]>(ALL_PRESETS);
+    const onValueChange = (newValue: number) => {
+        setValue(newValue);
+        onChange(newValue);
+    }
+
     useEffect(() => {
-        onChange?.(value)
-    }, [value, onChange])
-    const presets = [1000, 500, 200, 100, 50]
+        if (totalNodes) {
+            setPresets(ALL_PRESETS.filter(p => p < totalNodes));
+        }
+    }, [totalNodes]);
 
     return (
         <div
@@ -33,11 +42,16 @@ export default function NodeLimiter({ initialValue = 200, onChange, totalNodes, 
                     <Button size="sm" variant="outline">{value}</Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent>
+                    {totalNodes && (
+                        <DropdownMenuItem onClick={() => onValueChange(totalNodes)}>
+                            {totalNodes}
+                        </DropdownMenuItem>
+                    )}
                     {presets.map((preset) => (
                         <DropdownMenuItem
                             key={preset}
                             onClick={() => {
-                                setValue([preset])
+                                onValueChange(preset)
                             }}
                         >
                             {preset}

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,3 +63,11 @@ export interface GenreGraphData {
     nodes: Genre[];
     links: NodeLink[];
 }
+
+type KeysOfType<T, V> = {
+    [K in keyof T]-?: T[K] extends V ? K : never
+}[keyof T];
+
+export type GenreNodeLimitType = KeysOfType<Genre, number>;
+
+export type ArtistNodeLimitType = KeysOfType<Artist, number>;


### PR DESCRIPTION
Node limiter hooked up.
- Both artists and genres have their own node limiter; selections are stored between artists and genres tabs
- Defaults to all genres and 2000 artists
- No display in the similar artists graph
- Can filter the genres/artists by any numeric field; currently artistCount and listeners respectively
- Artist and genre links no longer mutated by graph