### PR TITLE
uses top 2000 artists by listeners when no genre is selected for artist tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,7 +61,14 @@ function App() {
   const [genreNodeCount, setGenreNodeCount] = useState<number>(0);
   const [artistNodeCount, setArtistNodeCount] = useState<number>(0);
   const { genres, genreLinks, genresLoading, genresError } = useGenres();
-  const { artists, artistLinks, artistsLoading, artistsError } = useGenreArtists(selectedGenre ? selectedGenre.id : undefined);
+  const {
+    artists,
+    artistLinks,
+    artistsLoading,
+    artistsError,
+    fetchAllArtists,
+    totalArtistsInDB
+  } = useGenreArtists(selectedGenre ? selectedGenre.id : undefined);
   const { similarArtists, similarArtistsLoading, similarArtistsError } = useSimilarArtists(selectedArtistNoGenre);
 
   const isMobile = useMediaQuery({ maxWidth: 640 });
@@ -90,8 +97,14 @@ function App() {
   }, [showArtistCard]);
 
   useEffect(() => {
-    const nodeCount = Math.min(artists.length, DEFAULT_NODE_COUNT);
-    onArtistNodeCountChange(nodeCount);
+    //console.log(artists.length)
+    if (selectedGenre) {
+      const nodeCount = Math.min(artists.length, DEFAULT_NODE_COUNT);
+      onArtistNodeCountChange(nodeCount);
+    } else {
+      setCurrentArtists(artists);
+      setCurrentArtistLinks(artistLinks);
+    }
   }, [artists]);
 
   useEffect(() => {
@@ -244,7 +257,9 @@ function App() {
   }
   const onArtistNodeCountChange = (count: number) => {
     setArtistNodeCount(count);
-    if (artists && artists.length && count < artists.length) {
+    if (!selectedGenre) {
+      fetchAllArtists(artistNodeLimitType, count);
+    } else if (artists && artists.length && count < artists.length) {
       const filteredArtists = artists
           .toSorted((a: Artist, b: Artist) => b[artistNodeLimitType] - a[artistNodeLimitType])
           .slice(0, count);
@@ -275,7 +290,22 @@ function App() {
       onGenreNodeClick(newGenre);
     }
   }
-
+  const onTabChange = async (graphType: GraphType) => {
+    if (graphType === 'genres') {
+      setGraph('genres');
+      if (selectedGenre) {
+        setCurrentArtists([]);
+        setCurrentArtistLinks([]);
+      }
+      setSelectedGenre(undefined);
+    } else {
+      setGraph('artists');
+      if (!selectedGenre && !currentArtists.length) {
+        setArtistNodeCount(DEFAULT_NODE_COUNT);
+        await fetchAllArtists(artistNodeLimitType, DEFAULT_NODE_COUNT);
+      }
+    }
+  }
 
   return (
     <SidebarProvider>
@@ -292,12 +322,12 @@ function App() {
           >
                <Tabs
                 value={graph}
-                onValueChange={(val) => setGraph(val as GraphType)}>
+                onValueChange={(val) => onTabChange(val as GraphType)}>
                   <TabsList>
                       <TabsTrigger
-                      onClick={() => setGraph('genres')} value="genres">Genres</TabsTrigger>
+                      onClick={() => onTabChange("genres")} value="genres">Genres</TabsTrigger>
                     <TabsTrigger
-                    onClick={() => setGraph('artists')} value="artists">Artists</TabsTrigger>
+                    onClick={() => onTabChange('artists')} value="artists">Artists</TabsTrigger>
                   </TabsList>
                 </Tabs>
                 { graph === 'artists' &&
@@ -347,7 +377,7 @@ function App() {
                 show={showGenreNodeLimiter()}
             />
             <NodeLimiter
-              totalNodes={artists.length}
+              totalNodes={artists && artists.length && selectedGenre ? artists.length : totalArtistsInDB ? totalArtistsInDB : DEFAULT_NODE_COUNT}
               nodeType={'artists'}
               initialValue={artistNodeCount}
               onChange={onArtistNodeCountChange}

--- a/src/components/AppSideBar.tsx
+++ b/src/components/AppSideBar.tsx
@@ -34,7 +34,7 @@ interface AppSidebarProps {
 export function AppSidebar({ children, onClick, selectedGenre, setSearchOpen, onLinkedGenreClick }: AppSidebarProps) {
   const [isExpanded, setIsExpanded] = useState(false)
   const { recentSelections } = useRecentSelections()
-  console.log("Recent selections in sidebar:", recentSelections);
+  //console.log("Recent selections in sidebar:", recentSelections);
 
   return (
     <>

--- a/src/components/NodeLimiter.tsx
+++ b/src/components/NodeLimiter.tsx
@@ -16,6 +16,7 @@ interface NodeLimiterProps {
   show: boolean;
 }
 
+const MAX_NODES = 40000;
 const ALL_PRESETS = [20000, 10000, 5000, 2000, 1000, 500, 200, 100, 50]
 
 export default function NodeLimiter({ initialValue, onChange, totalNodes, nodeType, show }: NodeLimiterProps) {
@@ -47,7 +48,7 @@ export default function NodeLimiter({ initialValue, onChange, totalNodes, nodeTy
                     <Button size="sm" variant="outline">{value}</Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent>
-                    {totalNodes && (
+                    {totalNodes && totalNodes < MAX_NODES && (
                         <DropdownMenuItem onClick={() => onValueChange(totalNodes)}>
                             {totalNodes}
                         </DropdownMenuItem>

--- a/src/hooks/useGenreArtists.tsx
+++ b/src/hooks/useGenreArtists.tsx
@@ -12,6 +12,7 @@ const useGenreArtists = (genreID?: string) => {
     const [artistLinks, setArtistLinks] = useState<NodeLink[]>([]);
     const [artistsLoading, setArtistsLoading] = useState(false);
     const [artistsError, setArtistsError] = useState<AxiosError>();
+    const [totalArtistsInDB, setTotalArtistsInDB] = useState<number | undefined>(undefined);
 
     const fetchArtists = async () => {
         if (genreID) {
@@ -29,11 +30,28 @@ const useGenreArtists = (genreID?: string) => {
         }
     }
 
+    const fetchAllArtists = async (filter?: string, amount?: number) => {
+        if (!genreID && filter && amount) {
+            setArtistsLoading(true);
+            try {
+                const response = await axios.get(`${url}/artists/${filter}/${amount}`);
+                setArtists(response.data.artists);
+                setArtistLinks(response.data.links);
+                setTotalArtistsInDB(response.data.count);
+            } catch (err) {
+                if (err instanceof AxiosError) {
+                    setArtistsError(err);
+                }
+            }
+            setArtistsLoading(false);
+        }
+    }
+
     useEffect(() => {
         fetchArtists();
     }, [genreID]);
 
-    return { artists, artistsLoading, artistsError, artistLinks };
+    return { artists, artistsLoading, artistsError, artistLinks, fetchAllArtists, totalArtistsInDB };
 }
 
 export default useGenreArtists;


### PR DESCRIPTION
- Loads top <node limiter amount> artists when no genre is selected
- Does a fetch for each time the node amount is changed (could possibly avoid this on node count changes to less than the current, but its kinda tricky)
- Artist nodes are preserved when switching to genres unless a genre is selected
- Internally limits nodes to 40000, highest option in UI is 20000
- Implemented by adding function to `useGenreArtists`
- I wonder how we can better filter the nodes so it's not just the top 2000 artists according to last.fm (currently internally has the capability to filter by any numerical field, but could be expanded)
- Update the server to use locally