### PR TITLE
get top artists from db based on count in tags

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,7 +73,8 @@ function App() {
     artistsLoading,
     artistsError,
     fetchAllArtists,
-    totalArtistsInDB
+    totalArtistsInDB,
+    topArtists
   } = useGenreArtists(selectedGenre ? selectedGenre.id : undefined);
   const { similarArtists, similarArtistsLoading, similarArtistsError } = useSimilarArtists(selectedArtistNoGenre);
   const [genreColorMap, setGenreColorMap] = useState<Map<string, string>>(new Map());
@@ -459,6 +460,7 @@ function App() {
                 }}
                 onSelectGenre={onLinkedGenreClick}
                 allArtists={onShowAllArtists}
+                topArtists={topArtists}
               />
               <ArtistInfo
                 selectedArtist={selectedArtist}

--- a/src/components/GenreInfo.tsx
+++ b/src/components/GenreInfo.tsx
@@ -21,6 +21,7 @@ interface GenreInfoProps {
   onLinkedGenreClick: (genreID: string) => void;
   limitRelated?: number;
   onTopArtistClick?: (artist: Artist) => void;
+  topArtists?: Artist[];
 }
 
 export function GenreInfo({
@@ -34,6 +35,7 @@ export function GenreInfo({
   onLinkedGenreClick,
   limitRelated = 5,
   onTopArtistClick,
+    topArtists,
 }: GenreInfoProps) {
   // On desktop, allow manual toggling of description; on mobile use snap state from panel
   const [desktopExpanded, setDesktopExpanded] = useState(true)
@@ -67,13 +69,6 @@ export function GenreInfo({
   const isDesktop = useMediaQuery("(min-width: 1200px)")
 
   const initial = selectedGenre?.name?.[0]?.toUpperCase() ?? '?'
-
-  // Top artists for this genre (by listeners)
-  const { artists: genreArtists } = useGenreArtists(selectedGenre?.id)
-  const topArtists = (genreArtists ?? [])
-    .slice()
-    .sort((a, b) => (b.listeners ?? 0) - (a.listeners ?? 0))
-    .slice(0, 8)
 
   // Prepare images for a bento carousel (desktop thumbnail area)
   const imageArtists = useMemo(
@@ -339,7 +334,7 @@ export function GenreInfo({
                   </div>
                 )}
                 {/* Top Artists */}
-                {topArtists.length > 0 && (
+                {topArtists && topArtists.length > 0 && (
                   <div className="flex flex-col gap-2">
                     <span className="text-md font-semibold">Top Artists</span>
                     <div className="flex flex-wrap items-center gap-1.5">

--- a/src/hooks/useGenreArtists.tsx
+++ b/src/hooks/useGenreArtists.tsx
@@ -8,18 +8,22 @@ const url = envBoolean(import.meta.env.VITE_USE_LOCAL_SERVER)
     : (import.meta.env.VITE_SERVER_URL
         || (import.meta.env.DEV ? '/api' : `https://rhizome-server-production.up.railway.app`));
 
-const useGenreArtists = (genreID?: string) => {
+const useGenreArtists = (genreID?: string, topAmount = 8) => {
     const [artists, setArtists] = useState<Artist[]>([]);
     const [artistLinks, setArtistLinks] = useState<NodeLink[]>([]);
     const [artistsLoading, setArtistsLoading] = useState(false);
     const [artistsError, setArtistsError] = useState<AxiosError>();
     const [totalArtistsInDB, setTotalArtistsInDB] = useState<number | undefined>(undefined);
+    const [topArtists, setTopArtists] = useState<Artist[]>([]);
 
     const fetchArtists = async () => {
         if (genreID) {
             setArtistsLoading(true);
             try {
+                const topRes = await axios.get(`${url}/artists/top/${genreID}/${topAmount}`);
+                setTopArtists(topRes.data);
                 const response = await axios.get(`${url}/artists/${genreID}`);
+
                 setArtists(response.data.artists);
                 setArtistLinks(response.data.links);
             } catch (err) {
@@ -52,7 +56,7 @@ const useGenreArtists = (genreID?: string) => {
         fetchArtists();
     }, [genreID]);
 
-    return { artists, artistsLoading, artistsError, artistLinks, fetchAllArtists, totalArtistsInDB };
+    return { artists, artistsLoading, artistsError, artistLinks, fetchAllArtists, totalArtistsInDB, topArtists };
 }
 
 export default useGenreArtists;


### PR DESCRIPTION
- topArtists added to useGenreArtists hook, fetched from db
- rather than by listeners, it's based on the top `count` amounts for the genre's corresponding tag
- removed now-unnecessary hook call in GenresFilter
- utilizes new server endpoint so server update needed for local use