### PR TITLE
Better selection indication for genre filter

### DIFF
--- a/src/components/GenresFilter.tsx
+++ b/src/components/GenresFilter.tsx
@@ -154,7 +154,7 @@ export default function GenresFilter({
     return selectedChildren[parent.id]?.has(childId) ?? false;
   };
 
-  // Show count of selected parents + selected children next to the trigger button.
+  // Show count of selected parents + selected children next to the clear button.
   const totalSelected = useMemo(() => {
     return topLevelGenres.reduce((acc, g) => {
       const parentCount = parentSelected[g.id] ? 1 : 0;

--- a/src/hooks/useTriStateSelection.ts
+++ b/src/hooks/useTriStateSelection.ts
@@ -51,9 +51,11 @@ export function useTriStateSelection<T extends { id: string }>(
     const children = getChildren(parent);
     const sel = selectedChildren[parent.id] ?? new Set<string>();
     const isParent = parentSelected[parent.id] ?? false;
-    if (!isParent) return "unchecked";
-    if (sel.size === children.length || sel.size === 0) return "checked";
-    return "indeterminate";
+    // If parent explicitly selected, show checked.
+    if (isParent) return "checked";
+    // Otherwise, any child selection indicates indeterminate.
+    if (sel.size > 0) return "indeterminate";
+    return "unchecked";
   };
 
   const toggleParent = (parent: T) => {
@@ -79,22 +81,16 @@ export function useTriStateSelection<T extends { id: string }>(
   };
 
   const toggleChild = (parent: T, child: T) => {
-    let newSize = 0;
     setSelectedChildren((prev) => {
       const copy = { ...prev };
       const set = new Set<string>(copy[parent.id] ?? []);
       if (set.has(child.id)) set.delete(child.id);
       else set.add(child.id);
       copy[parent.id] = set;
-      newSize = set.size;
       return copy;
     });
 
-    // If any child is selected, ensure the parent is marked selected.
-    if (newSize > 0) {
-      setParentSelected((prev) => ({ ...prev, [parent.id]: true }));
-    }
-
+    // Do not auto-select the parent; let tri-state reflect children.
     onChildClick?.(child, parent);
   };
 
@@ -108,4 +104,3 @@ export function useTriStateSelection<T extends { id: string }>(
     toggleChild,
   } as const;
 }
-


### PR DESCRIPTION
**Changes**
- Uses es isTopLevelGenre correctly
- Adds a selected section to the genre filter that displays a flat list of selected genres
- selected items have a unique id to prevent duplicate hover effects
- Wrap the “Selected” group in a measuring div with ref={selectedGroupRef} and useLayoutEffect to preserve scroll by adjusting scrollTop based on “Selected” group height delta
