### PR TITLE
Genre info to artist info

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,9 @@ import {
   buildGenreRootColorMap,
   buildGenreTree,
   filterOutGenreTree,
-  generateSimilarLinks, mixColors
+  generateSimilarLinks, 
+  mixColors, 
+  fixWikiImageURL
 } from "@/lib/utils";
 import ClusteringPanel from "@/components/ClusteringPanel";
 import { ModeToggle } from './components/ModeToggle';
@@ -172,6 +174,11 @@ function App() {
     if (artist) {
       onArtistNodeClick(artist);
     }
+  }
+  const getArtistImageByName = (name: string) => {
+    const a = currentArtists.find((x) => x.name === name);
+    const raw = a?.image as string | undefined;
+    return raw ? fixWikiImageURL(raw) : undefined;
   }
   const onGenreNodeClick = (genre: Genre) => {
     // this code makes the mini genre graph
@@ -602,6 +609,7 @@ function App() {
                 similarFilter={similarArtistFilter}
                 onBadDataSubmit={onBadDataArtistSubmit}
                 onGenreClick={onGenreNameClick}
+                getArtistImageByName={getArtistImageByName}
               />
 
             {/* Show reset button in desktop header when Artists view is pre-filtered by a selected genre */}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -593,7 +593,6 @@ function App() {
                 onLinkedGenreClick={onLinkedGenreClick}
                 show={graph === 'genres' && !!selectedGenre && !showArtistCard}
                 genreLoading={artistsLoading}
-                genreColorMap={genreColorMap}
                 onTopArtistClick={onTopArtistClick}
                 deselectGenre={() => {
                   setSelectedGenre(undefined);
@@ -606,6 +605,7 @@ function App() {
                 onBadDataSubmit={onBadDataGenreSubmit}
                 topArtists={topArtists}
                 getArtistImageByName={getArtistImageByName}
+                genreColorMap={genreColorMap}
               />
               <ArtistInfo
                 selectedArtist={selectedArtist}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -598,6 +598,7 @@ function App() {
                 allArtists={onShowAllArtists}
                 onBadDataSubmit={onBadDataGenreSubmit}
                 topArtists={topArtists}
+                getArtistImageByName={getArtistImageByName}
               />
               <ArtistInfo
                 selectedArtist={selectedArtist}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -183,6 +183,9 @@ function App() {
   const getArtistByName = (name: string) => {
     return currentArtists.find((a) => a.name === name);
   }
+  const getGenreNameById = (id: string) => {
+    return genres.find((g) => g.id === id)?.name;
+  }
   const onGenreNodeClick = (genre: Genre) => {
     // this code makes the mini genre graph
     // if (genreHasChildren(genre, genreClusterMode)) {
@@ -617,6 +620,7 @@ function App() {
                 getArtistByName={getArtistByName}
                 genreColorMap={genreColorMap}
                 getArtistColor={getArtistColor}
+                getGenreNameById={getGenreNameById}
               />
 
             {/* Show reset button in desktop header when Artists view is pre-filtered by a selected genre */}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -415,8 +415,9 @@ function App() {
     }
     return success;
   }
-  const getRootGenreFromTags = (tags: Tag[]) => {
-    const genreTags = tags.filter(t => genres.some((g) => g.name === t.name));
+  const getRootGenreFromTags = (tags?: Tag[] | null) => {
+    const safeTags = tags ?? [];
+    const genreTags = safeTags.filter(t => genres.some((g) => g.name === t.name));
     if (genreTags.length > 0) {
       const bestTag = genreTags.sort((a, b) => b.count - a.count)[0];
       const tagGenre = genres.find((g) => g.name === bestTag.name);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -606,6 +606,7 @@ function App() {
                 topArtists={topArtists}
                 getArtistImageByName={getArtistImageByName}
                 genreColorMap={genreColorMap}
+                getArtistColor={getArtistColor}
               />
               <ArtistInfo
                 selectedArtist={selectedArtist}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -322,6 +322,15 @@ function App() {
       onGenreNodeClick(newGenre);
     }
   }
+  const onGenreNameClick = (name: string) => {
+    const newGenre = genres.find((g) => g.name === name);
+    if (newGenre) {
+      setGraph('genres');
+      onGenreNodeClick(newGenre);
+    } else {
+      toast.error(`Genre not found: ${name}`);
+    }
+  }
   const onTabChange = async (graphType: GraphType) => {
     if (graphType === 'genres') {
       setGraph('genres');
@@ -592,6 +601,7 @@ function App() {
                 deselectArtist={deselectArtist}
                 similarFilter={similarArtistFilter}
                 onBadDataSubmit={onBadDataArtistSubmit}
+                onGenreClick={onGenreNameClick}
               />
 
             {/* Show reset button in desktop header when Artists view is pre-filtered by a selected genre */}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -593,6 +593,7 @@ function App() {
                 onLinkedGenreClick={onLinkedGenreClick}
                 show={graph === 'genres' && !!selectedGenre && !showArtistCard}
                 genreLoading={artistsLoading}
+                genreColorMap={genreColorMap}
                 onTopArtistClick={onTopArtistClick}
                 deselectGenre={() => {
                   setSelectedGenre(undefined);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -180,6 +180,9 @@ function App() {
     const raw = a?.image as string | undefined;
     return raw ? fixWikiImageURL(raw) : undefined;
   }
+  const getArtistByName = (name: string) => {
+    return currentArtists.find((a) => a.name === name);
+  }
   const onGenreNodeClick = (genre: Genre) => {
     // this code makes the mini genre graph
     // if (genreHasChildren(genre, genreClusterMode)) {
@@ -611,6 +614,9 @@ function App() {
                 onBadDataSubmit={onBadDataArtistSubmit}
                 onGenreClick={onGenreNameClick}
                 getArtistImageByName={getArtistImageByName}
+                getArtistByName={getArtistByName}
+                genreColorMap={genreColorMap}
+                getArtistColor={getArtistColor}
               />
 
             {/* Show reset button in desktop header when Artists view is pre-filtered by a selected genre */}

--- a/src/components/ArtistBadge.tsx
+++ b/src/components/ArtistBadge.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+
+interface ArtistBadgeProps {
+  name: string;
+  onClick: () => void;
+  imageUrl?: string;
+  accentColor?: string;
+  title?: string;
+}
+
+export default function ArtistBadge({
+  name,
+  onClick,
+  imageUrl,
+  accentColor,
+  title,
+}: ArtistBadgeProps) {
+  const initial = name?.[0]?.toUpperCase() ?? '?';
+  return (
+    <Badge asChild variant="outline" title={title ?? `Go to ${name}`}> 
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={onClick}
+        className="cursor-pointer inline-flex items-center gap-1.5"
+      >
+        <span
+          className="inline-flex items-center justify-center rounded-full border-1 size-5"
+          style={{ borderColor: accentColor }}
+        >
+          {imageUrl ? (
+            <img
+              src={imageUrl}
+              alt={`${name} avatar`}
+              className="w-full h-full rounded-full object-cover"
+              loading="lazy"
+            />
+          ) : (
+            <span className="w-full h-full rounded-full bg-muted text-[10px] leading-4 text-center">
+              {initial}
+            </span>
+          )}
+        </span>
+        {name}
+      </Button>
+    </Badge>
+  );
+}

--- a/src/components/ArtistInfo.tsx
+++ b/src/components/ArtistInfo.tsx
@@ -301,18 +301,18 @@ export function ArtistInfo({
                               className="cursor-pointer inline-flex items-center gap-1.5"
                             >
                               <span
-                                className="inline-flex items-center justify-center rounded-full border-2 w-[18px] h-[18px] p-[1px]"
+                                className="inline-flex items-center justify-center rounded-full border-1 size-5"
                                 style={{ borderColor: accent }}
                               >
                                 {img ? (
                                   <img
                                     src={img}
                                     alt={`${name} avatar`}
-                                    className="w-4 h-4 rounded-full object-cover"
+                                    className="w-full h-full rounded-full object-cover"
                                     loading="lazy"
                                   />
                                 ) : (
-                                  <span className="w-4 h-4 rounded-full bg-muted text-[10px] leading-4 text-center">
+                                  <span className="w-full h-full rounded-full bg-muted text-[10px] leading-4 text-center">
                                     {initial}
                                   </span>
                                 )}

--- a/src/components/ArtistInfo.tsx
+++ b/src/components/ArtistInfo.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { ResponsiveDrawer } from "@/components/ResponsiveDrawer";
-import { fixWikiImageURL, formatDate, formatNumber } from "@/lib/utils";
+import { fixWikiImageURL, formatDate, formatNumber, clusterColors } from "@/lib/utils";
 import { CirclePlay, SquarePlus, Ellipsis, Info, Flag } from "lucide-react";
 import { toast } from "sonner";
 import {
@@ -99,6 +99,9 @@ export function ArtistInfo({
     }
   }
 
+  const artistGenres = [
+    { name: ''}
+  ]
 
 
   if (!show) return null;
@@ -295,18 +298,28 @@ export function ArtistInfo({
                   <div className="flex flex-col gap-2">
                     <span className="text-md font-semibold">Genres</span>
                     <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
-                      {selectedArtist.genres.map((g, i) => (
-                        <>
-                          {onGenreClick ? (
-                            <Button variant="link" size="lg" key={`${g}-${i}`} onClick={() => onGenreClick(g)}>
-                              {g}
-                            </Button>
-                          ) : (
-                            <span key={`${g}-${i}`}>{g}</span>
-                          )}
-                          {i < selectedArtist.genres.length - 1 ? ' · ' : ''}
-                        </>
-                      ))}
+                      {selectedArtist.genres.map((name) => {
+                        const key = `${name}`;
+                        // Simple stable color selection from cluster palette
+                        const token = String(name).toLowerCase();
+                        let hash = 0;
+                        for (let i = 0; i < token.length; i++) {
+                          hash = (hash * 31 + token.charCodeAt(i)) >>> 0;
+                        }
+                        const color = clusterColors[hash % clusterColors.length];
+                        return (
+                          <>
+                            {onGenreClick && (
+                              <Badge key={key} variant="outline" title={`Go to ${name}`} asChild>
+                                <Button variant="ghost" size="sm" onClick={() => onGenreClick(name)} className="cursor-pointer inline-flex items-center gap-1">
+                                  <span className="inline-block rounded-full h-2 w-2" style={{ backgroundColor: color }} />
+                                  {name}
+                                </Button>
+                              </Badge>
+                            )}
+                          </>
+                        );
+                      })}
                     </div>
                   </div>
                 )}

--- a/src/components/ArtistInfo.tsx
+++ b/src/components/ArtistInfo.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/dropdown-menu"
 import ReportIncorrectInfoDialog from "@/components/ReportIncorrectInfoDialog";
 import { Alert, AlertDescription } from "./ui/alert";
+import ArtistBadge from "@/components/ArtistBadge";
 
 
 interface ArtistInfoProps {
@@ -290,36 +291,16 @@ export function ArtistInfo({
                       {similarFilter(selectedArtist.similar).map((name) => {
                         const img = getArtistImageByName?.(name);
                         const artistObj = getArtistByName?.(name);
-                        const accent = getArtistColor(artistObj!);
-                        const initial = name?.[0]?.toUpperCase() ?? '?';
+                        const accent = artistObj ? getArtistColor(artistObj) : undefined;
                         return (
-                          <Badge key={name} asChild variant="outline" title={`Go to ${name}`}>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => setArtistFromName(name)}
-                              className="cursor-pointer inline-flex items-center gap-1.5"
-                            >
-                              <span
-                                className="inline-flex items-center justify-center rounded-full border-1 size-5"
-                                style={{ borderColor: accent }}
-                              >
-                                {img ? (
-                                  <img
-                                    src={img}
-                                    alt={`${name} avatar`}
-                                    className="w-full h-full rounded-full object-cover"
-                                    loading="lazy"
-                                  />
-                                ) : (
-                                  <span className="w-full h-full rounded-full bg-muted text-[10px] leading-4 text-center">
-                                    {initial}
-                                  </span>
-                                )}
-                              </span>
-                              {name}
-                            </Button>
-                          </Badge>
+                          <ArtistBadge
+                            key={name}
+                            name={name}
+                            imageUrl={img}
+                            accentColor={accent}
+                            onClick={() => setArtistFromName(name)}
+                            title={`Go to ${name}`}
+                          />
                         );
                       })}
                     </div>

--- a/src/components/ArtistInfo.tsx
+++ b/src/components/ArtistInfo.tsx
@@ -291,13 +291,13 @@ export function ArtistInfo({
                       {similarFilter(selectedArtist.similar).map((name) => {
                         const img = getArtistImageByName?.(name);
                         const artistObj = getArtistByName?.(name);
-                        const accent = artistObj ? getArtistColor(artistObj) : undefined;
+                        const genreColor = artistObj ? getArtistColor(artistObj) : undefined;
                         return (
                           <ArtistBadge
                             key={name}
                             name={name}
                             imageUrl={img}
-                            accentColor={accent}
+                            genreColor={genreColor}
                             onClick={() => setArtistFromName(name)}
                             title={`Go to ${name}`}
                           />

--- a/src/components/ArtistInfo.tsx
+++ b/src/components/ArtistInfo.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { ResponsiveDrawer } from "@/components/ResponsiveDrawer";
-import { fixWikiImageURL, formatDate, formatNumber, clusterColors } from "@/lib/utils";
+import { fixWikiImageURL, formatDate, formatNumber } from "@/lib/utils";
 import { CirclePlay, SquarePlus, Ellipsis, Info, Flag } from "lucide-react";
 import { toast } from "sonner";
 import {
@@ -28,6 +28,9 @@ interface ArtistInfoProps {
   onBadDataSubmit: (id: string, reason: string, type: 'genre' | 'artist', hasFlag: boolean, details?: string) => Promise<boolean>;
   onGenreClick?: (name: string) => void;
   getArtistImageByName?: (name: string) => string | undefined;
+  getArtistByName?: (name: string) => Artist | undefined;
+  genreColorMap?: Map<string, string>;
+  getArtistColor: (artist: Artist) => string;
 }
 
 export function ArtistInfo({
@@ -41,6 +44,9 @@ export function ArtistInfo({
   onBadDataSubmit,
   onGenreClick,
   getArtistImageByName,
+  getArtistByName,
+  genreColorMap,
+  getArtistColor,
 }: ArtistInfoProps) {
   const [desktopExpanded, setDesktopExpanded] = useState(true);
   const [reportDialogOpen, setReportDialogOpen] = useState(false);
@@ -281,6 +287,8 @@ export function ArtistInfo({
                     <div className="flex flex-wrap items-center gap-1.5">
                       {similarFilter(selectedArtist.similar).map((name) => {
                         const img = getArtistImageByName?.(name);
+                        const artistObj = getArtistByName?.(name);
+                        const accent = getArtistColor(artistObj!);
                         const initial = name?.[0]?.toUpperCase() ?? '?';
                         return (
                           <Badge key={name} asChild variant="outline" title={`Go to ${name}`}>
@@ -290,18 +298,23 @@ export function ArtistInfo({
                               onClick={() => setArtistFromName(name)}
                               className="cursor-pointer inline-flex items-center gap-1.5"
                             >
-                              {img ? (
-                                <img
-                                  src={img}
-                                  alt={`${name} avatar`}
-                                  className="w-4 h-4 rounded-full object-cover"
-                                  loading="lazy"
-                                />
-                              ) : (
-                                <span className="w-4 h-4 rounded-full bg-muted text-[10px] leading-4 text-center">
-                                  {initial}
-                                </span>
-                              )}
+                              <span
+                                className="inline-flex items-center justify-center rounded-full border-2 w-[18px] h-[18px] p-[1px]"
+                                style={{ borderColor: accent }}
+                              >
+                                {img ? (
+                                  <img
+                                    src={img}
+                                    alt={`${name} avatar`}
+                                    className="w-4 h-4 rounded-full object-cover"
+                                    loading="lazy"
+                                  />
+                                ) : (
+                                  <span className="w-4 h-4 rounded-full bg-muted text-[10px] leading-4 text-center">
+                                    {initial}
+                                  </span>
+                                )}
+                              </span>
                               {name}
                             </Button>
                           </Badge>
@@ -318,19 +331,13 @@ export function ArtistInfo({
                     <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
                       {selectedArtist.genres.map((name) => {
                         const key = `${name}`;
-                        // Simple stable color selection from cluster palette
-                        const token = String(name).toLowerCase();
-                        let hash = 0;
-                        for (let i = 0; i < token.length; i++) {
-                          hash = (hash * 31 + token.charCodeAt(i)) >>> 0;
-                        }
-                        const color = clusterColors[hash % clusterColors.length];
                         return (
                           <>
                             {onGenreClick && (
                               <Badge key={key} variant="outline" title={`Go to ${name}`} asChild>
                                 <Button variant="ghost" size="sm" onClick={() => onGenreClick(name)} className="cursor-pointer inline-flex items-center gap-1">
-                                  <span className="inline-block rounded-full h-2 w-2" style={{ backgroundColor: color }} />
+                                  {/* TODO: Hook up genre color */}
+                                  <span className="inline-block rounded-full h-2 w-2 bg-amber-400" />
                                   {name}
                                 </Button>
                               </Badge>

--- a/src/components/ArtistInfo.tsx
+++ b/src/components/ArtistInfo.tsx
@@ -31,6 +31,7 @@ interface ArtistInfoProps {
   getArtistByName?: (name: string) => Artist | undefined;
   genreColorMap?: Map<string, string>;
   getArtistColor: (artist: Artist) => string;
+  getGenreNameById?: (id: string) => string | undefined;
 }
 
 export function ArtistInfo({
@@ -47,6 +48,7 @@ export function ArtistInfo({
   getArtistByName,
   genreColorMap,
   getArtistColor,
+  getGenreNameById,
 }: ArtistInfoProps) {
   const [desktopExpanded, setDesktopExpanded] = useState(true);
   const [reportDialogOpen, setReportDialogOpen] = useState(false);
@@ -329,15 +331,19 @@ export function ArtistInfo({
                   <div className="flex flex-col gap-2">
                     <span className="text-md font-semibold">Genres</span>
                     <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
-                      {selectedArtist.genres.map((name) => {
-                        const key = `${name}`;
+                      {selectedArtist.genres.map((genreId) => {
+                        const name = getGenreNameById?.(genreId) ?? genreId;
+                        const key = `${genreId}`;
+                        const genreColor = genreColorMap?.get(genreId);
                         return (
                           <>
                             {onGenreClick && (
                               <Badge key={key} variant="outline" title={`Go to ${name}`} asChild>
                                 <Button variant="ghost" size="sm" onClick={() => onGenreClick(name)} className="cursor-pointer inline-flex items-center gap-1">
-                                  {/* TODO: Hook up genre color */}
-                                  <span className="inline-block rounded-full h-2 w-2 bg-amber-400" />
+                                  <span
+                                    className="inline-block rounded-full h-2 w-2"
+                                    style={{ backgroundColor: genreColor ?? '#fbbf24' }}
+                                  />
                                   {name}
                                 </Button>
                               </Badge>

--- a/src/components/ArtistInfo.tsx
+++ b/src/components/ArtistInfo.tsx
@@ -27,6 +27,7 @@ interface ArtistInfoProps {
   similarFilter: (artists: string[]) => string[];
   onBadDataSubmit: (id: string, reason: string, type: 'genre' | 'artist', hasFlag: boolean, details?: string) => Promise<boolean>;
   onGenreClick?: (name: string) => void;
+  getArtistImageByName?: (name: string) => string | undefined;
 }
 
 export function ArtistInfo({
@@ -39,6 +40,7 @@ export function ArtistInfo({
   similarFilter,
   onBadDataSubmit,
   onGenreClick,
+  getArtistImageByName,
 }: ArtistInfoProps) {
   const [desktopExpanded, setDesktopExpanded] = useState(true);
   const [reportDialogOpen, setReportDialogOpen] = useState(false);
@@ -277,18 +279,34 @@ export function ArtistInfo({
                   <div className="flex flex-col gap-2">
                     <span className="text-md font-semibold">Similar Artists</span>
                     <div className="flex flex-wrap items-center gap-1.5">
-                      {similarFilter(selectedArtist.similar).map((name) => (
-                        <Badge key={name} asChild variant="outline" title={`Go to ${name}`}>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => setArtistFromName(name)}
-                            className="cursor-pointer"
-                          >
-                            {name}
-                          </Button>
-                        </Badge>
-                      ))}
+                      {similarFilter(selectedArtist.similar).map((name) => {
+                        const img = getArtistImageByName?.(name);
+                        const initial = name?.[0]?.toUpperCase() ?? '?';
+                        return (
+                          <Badge key={name} asChild variant="outline" title={`Go to ${name}`}>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => setArtistFromName(name)}
+                              className="cursor-pointer inline-flex items-center gap-1.5"
+                            >
+                              {img ? (
+                                <img
+                                  src={img}
+                                  alt={`${name} avatar`}
+                                  className="w-4 h-4 rounded-full object-cover"
+                                  loading="lazy"
+                                />
+                              ) : (
+                                <span className="w-4 h-4 rounded-full bg-muted text-[10px] leading-4 text-center">
+                                  {initial}
+                                </span>
+                              )}
+                              {name}
+                            </Button>
+                          </Badge>
+                        );
+                      })}
                     </div>
                   </div>
                 )}

--- a/src/components/ArtistInfo.tsx
+++ b/src/components/ArtistInfo.tsx
@@ -26,6 +26,7 @@ interface ArtistInfoProps {
   setArtistFromName: (name: string) => void;
   similarFilter: (artists: string[]) => string[];
   onBadDataSubmit: (id: string, reason: string, type: 'genre' | 'artist', hasFlag: boolean, details?: string) => Promise<boolean>;
+  onGenreClick?: (name: string) => void;
 }
 
 export function ArtistInfo({
@@ -37,6 +38,7 @@ export function ArtistInfo({
   setArtistFromName,
   similarFilter,
   onBadDataSubmit,
+  onGenreClick,
 }: ArtistInfoProps) {
   const [desktopExpanded, setDesktopExpanded] = useState(true);
   const [reportDialogOpen, setReportDialogOpen] = useState(false);
@@ -283,6 +285,27 @@ export function ArtistInfo({
                             {name}
                           </Button>
                         </Badge>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {/* Genres */}
+                {selectedArtist?.genres && selectedArtist.genres.length > 0 && (
+                  <div className="flex flex-col gap-2">
+                    <span className="text-md font-semibold">Genres</span>
+                    <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
+                      {selectedArtist.genres.map((g, i) => (
+                        <>
+                          {onGenreClick ? (
+                            <Button variant="link" size="lg" key={`${g}-${i}`} onClick={() => onGenreClick(g)}>
+                              {g}
+                            </Button>
+                          ) : (
+                            <span key={`${g}-${i}`}>{g}</span>
+                          )}
+                          {i < selectedArtist.genres.length - 1 ? ' · ' : ''}
+                        </>
                       ))}
                     </div>
                   </div>

--- a/src/components/ArtistInfo.tsx
+++ b/src/components/ArtistInfo.tsx
@@ -16,6 +16,7 @@ import {
 import ReportIncorrectInfoDialog from "@/components/ReportIncorrectInfoDialog";
 import { Alert, AlertDescription } from "./ui/alert";
 import ArtistBadge from "@/components/ArtistBadge";
+import GenreBadge from "@/components/GenreBadge";
 
 
 interface ArtistInfoProps {
@@ -319,15 +320,13 @@ export function ArtistInfo({
                         return (
                           <>
                             {onGenreClick && (
-                              <Badge key={key} variant="outline" title={`Go to ${name}`} asChild>
-                                <Button variant="ghost" size="sm" onClick={() => onGenreClick(name)} className="cursor-pointer inline-flex items-center gap-1">
-                                  <span
-                                    className="inline-block rounded-full h-2 w-2"
-                                    style={{ backgroundColor: genreColor ?? '#fbbf24' }}
-                                  />
-                                  {name}
-                                </Button>
-                              </Badge>
+                              <GenreBadge
+                                key={key}
+                                name={name}
+                                genreColor={genreColor}
+                                onClick={() => onGenreClick(name)}
+                                title={`Go to ${name}`}
+                              />
                             )}
                           </>
                         );

--- a/src/components/GenreBadge.tsx
+++ b/src/components/GenreBadge.tsx
@@ -14,7 +14,6 @@ export default function GenreBadge({
   genreColor,
   title,
 }: GenreBadgeProps) {
-  const initial = name?.[0]?.toUpperCase() ?? '?';
   return (
     <Badge asChild variant="outline" title={title ?? `Go to ${name}`}> 
       <Button
@@ -27,7 +26,6 @@ export default function GenreBadge({
         className="inline-block rounded-full h-2 w-2"
         style={{ backgroundColor: genreColor ?? '#ffffff' }}
         />
-            {initial}
         {name}
       </Button>
     </Badge>

--- a/src/components/GenreBadge.tsx
+++ b/src/components/GenreBadge.tsx
@@ -24,13 +24,10 @@ export default function GenreBadge({
         className="cursor-pointer inline-flex items-center gap-1.5"
       >
         <span
-          className="inline-flex items-center justify-center rounded-full border-1 size-5"
-          style={{ backgroundColor: genreColor ?? '#ffffff' }}
-        >
-          <span className="w-full h-full rounded-full bg-muted text-[10px] leading-4 text-center">
+        className="inline-block rounded-full h-2 w-2"
+        style={{ backgroundColor: genreColor ?? '#ffffff' }}
+        />
             {initial}
-          </span>
-        </span>
         {name}
       </Button>
     </Badge>

--- a/src/components/GenreBadge.tsx
+++ b/src/components/GenreBadge.tsx
@@ -1,21 +1,19 @@
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 
-interface ArtistBadgeProps {
+interface GenreBadgeProps {
   name: string;
   onClick: () => void;
-  imageUrl?: string;
   genreColor?: string;
   title?: string;
 }
 
-export default function ArtistBadge({
+export default function GenreBadge({
   name,
   onClick,
-  imageUrl,
   genreColor,
   title,
-}: ArtistBadgeProps) {
+}: GenreBadgeProps) {
   const initial = name?.[0]?.toUpperCase() ?? '?';
   return (
     <Badge asChild variant="outline" title={title ?? `Go to ${name}`}> 
@@ -27,20 +25,11 @@ export default function ArtistBadge({
       >
         <span
           className="inline-flex items-center justify-center rounded-full border-1 size-5"
-          style={{ borderColor: genreColor }}
+          style={{ backgroundColor: genreColor ?? '#ffffff' }}
         >
-          {imageUrl ? (
-            <img
-              src={imageUrl}
-              alt={`${name} avatar`}
-              className="w-full h-full rounded-full object-cover"
-              loading="lazy"
-            />
-          ) : (
-            <span className="w-full h-full rounded-full bg-muted text-[10px] leading-4 text-center">
-              {initial}
-            </span>
-          )}
+          <span className="w-full h-full rounded-full bg-muted text-[10px] leading-4 text-center">
+            {initial}
+          </span>
         </span>
         {name}
       </Button>

--- a/src/components/GenreInfo.tsx
+++ b/src/components/GenreInfo.tsx
@@ -27,6 +27,7 @@ interface GenreInfoProps {
   onBadDataSubmit: (id: string, reason: string, type: 'genre' | 'artist', hasFlag: boolean, details?: string) => Promise<boolean>;
   topArtists?: Artist[];
   getArtistImageByName?: (name: string) => string | undefined;
+  genreColorMap?: Map<string, string>;
 }
 
 export function GenreInfo({
@@ -43,6 +44,7 @@ export function GenreInfo({
     onBadDataSubmit,
     topArtists,
     getArtistImageByName,
+    genreColorMap,
 }: GenreInfoProps) {
   // On desktop, allow manual toggling of description; on mobile use snap state from panel
   const [desktopExpanded, setDesktopExpanded] = useState(true)
@@ -59,17 +61,28 @@ export function GenreInfo({
     return (
       <div className="flex flex-col items-start gap-2">
         <span className="text-md font-medium text-muted-foreground">{label}:</span>
-        <div className='flex items-center gap-1 flex-wrap'>
-          {items.map((node, i) => (
-            <>
-              {onLinkedGenreClick ? (
-                <Badge asChild variant={'outline'} ><Button variant="ghost" size="sm" key={node.id} onClick={() => onLinkedGenreClick(node.id)}>{node.name}</Button></Badge>
-              ) : (
-                <span key={node.id}>{node.name}</span>
-              )}
-              {/* {i < items.length - 1 ? ' · ' : ''} */}
-            </>
-          ))}
+        <div className='flex items-center gap-1.5 flex-wrap'>
+          {items.map((node, i) => {
+            const genreColor = genreColorMap?.get(node.id);
+            return (
+              <>
+                {onLinkedGenreClick ? (
+                  <Badge asChild variant={'outline'} key={node.id}>
+                    <Button variant="ghost" size="sm" onClick={() => onLinkedGenreClick(node.id)}>
+                      <span
+                        className="inline-block rounded-full h-2 w-2"
+                        style={{ backgroundColor: genreColor ?? '#ffffff' }}
+                      />
+                      {node.name}
+                    </Button>
+                  </Badge>
+                ) : (
+                  <span key={node.id}>{node.name}</span>
+                )}
+                {/* {i < items.length - 1 ? ' · ' : ''} */}
+              </>
+            );
+          })}
         </div>
       </div>
     )

--- a/src/components/GenreInfo.tsx
+++ b/src/components/GenreInfo.tsx
@@ -10,6 +10,7 @@ import { ResponsiveDrawer } from "@/components/ResponsiveDrawer";
 import ReportIncorrectInfoDialog from "@/components/ReportIncorrectInfoDialog";
 import { toast } from "sonner";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import ArtistBadge from "@/components/ArtistBadge";
 
 
 
@@ -405,33 +406,14 @@ export function GenreInfo({
                         : undefined;
                       const initial = artist.name?.[0]?.toUpperCase() ?? '?';
                       return (
-                        <Badge
-                          key={artist.id}
-                          asChild
-                          variant="outline"
-                          title={`${artist.listeners?.toLocaleString() ?? 0} listeners`}
-                        >
-                            <Button variant="ghost" size="sm" onClick={() => onTopArtistClick?.(artist)} className="cursor-pointer">
-                             <span
-                                className="inline-flex items-center justify-center rounded-full border-1 size-5"
-                                style={{ borderColor: accent }}
-                              >
-                            {img ? (
-                              <img
-                                src={img}
-                                alt={`${artist.name} avatar`}
-                                className="w-full h-full rounded-full object-cover"
-                                loading="lazy"
-                              />
-                            ) : (
-                              <span className="w-full h-full rounded-full bg-muted text-[10px] leading-4 text-center">
-                                {initial}
-                              </span>
-                            )}
-                            </span>
-                              {artist.name}
-                            </Button>
-                        </Badge>
+                        <ArtistBadge
+                            key={artist.name}
+                            name={artist.name}
+                            imageUrl={img}
+                            accentColor={accent}
+                            onClick={() =>onTopArtistClick?.(artist)}
+                            title={`Go to ${artist.name}`}
+                          />
                       );
                     })}
                     </div>

--- a/src/components/GenreInfo.tsx
+++ b/src/components/GenreInfo.tsx
@@ -11,6 +11,7 @@ import ReportIncorrectInfoDialog from "@/components/ReportIncorrectInfoDialog";
 import { toast } from "sonner";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import ArtistBadge from "@/components/ArtistBadge";
+import GenreBadge from "@/components/GenreBadge";
 
 
 
@@ -68,22 +69,13 @@ export function GenreInfo({
           {items.map((node, i) => {
             const genreColor = genreColorMap?.get(node.id);
             return (
-              <>
-                {onLinkedGenreClick ? (
-                  <Badge asChild variant={'outline'} key={node.id}>
-                    <Button variant="ghost" size="sm" onClick={() => onLinkedGenreClick(node.id)}>
-                      <span
-                        className="inline-block rounded-full h-2 w-2"
-                        style={{ backgroundColor: genreColor ?? '#ffffff' }}
-                      />
-                      {node.name}
-                    </Button>
-                  </Badge>
-                ) : (
-                  <span key={node.id}>{node.name}</span>
-                )}
-                {/* {i < items.length - 1 ? ' · ' : ''} */}
-              </>
+              <GenreBadge
+                key={node.id}
+                name={node.name}
+                onClick={() => onLinkedGenreClick(node.id)}
+                genreColor={genreColor}
+                title={`Go to ${node.name}`}
+              />
             );
           })}
         </div>

--- a/src/components/GenreInfo.tsx
+++ b/src/components/GenreInfo.tsx
@@ -57,13 +57,13 @@ export function GenreInfo({
     if (!nodes || nodes.length === 0) return null
     const items = nodes.slice(0, limitRelated)
     return (
-      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
+      <div className="flex flex-col items-start gap-x-1.5 gap-3">
         <span className="text-md text-muted-foreground">{label}:</span>
         <div className='flex items-center gap-1.5 flex-wrap'>
           {items.map((node, i) => (
             <>
               {onLinkedGenreClick ? (
-                <Button variant="link" size="lg" key={node.id} onClick={() => onLinkedGenreClick(node.id)}>{node.name}</Button>
+                <Badge asChild variant={'outline'} ><Button variant="ghost" size="sm" key={node.id} onClick={() => onLinkedGenreClick(node.id)}>{node.name}</Button></Badge>
               ) : (
                 <span key={node.id}>{node.name}</span>
               )}

--- a/src/components/GenreInfo.tsx
+++ b/src/components/GenreInfo.tsx
@@ -413,11 +413,11 @@ export function GenreInfo({
                               <img
                                 src={img}
                                 alt={`${artist.name} avatar`}
-                                className="w-4 h-4 rounded-full object-cover"
+                                className="size-5 rounded-full object-cover"
                                 loading="lazy"
                               />
                             ) : (
-                              <span className="w-4 h-4 rounded-full bg-muted text-[10px] leading-4 text-center">
+                              <span className="size-5 rounded-full bg-muted text-[10px] leading-4 text-center">
                                 {initial}
                               </span>
                             )}

--- a/src/components/GenreInfo.tsx
+++ b/src/components/GenreInfo.tsx
@@ -384,7 +384,9 @@ export function GenreInfo({
                     <span className="text-md font-semibold">Top Artists</span>
                     <div className="flex flex-wrap items-center gap-1.5">
                     {topArtists.map((artist) => {
-                      const img = getArtistImageByName?.(artist.name);
+                      const img = typeof artist.image === 'string' && artist.image.trim()
+                        ? fixWikiImageURL(artist.image as string)
+                        : undefined;
                       const initial = artist.name?.[0]?.toUpperCase() ?? '?';
                       return (
                         <Badge

--- a/src/components/GenreInfo.tsx
+++ b/src/components/GenreInfo.tsx
@@ -28,6 +28,7 @@ interface GenreInfoProps {
   topArtists?: Artist[];
   getArtistImageByName?: (name: string) => string | undefined;
   genreColorMap?: Map<string, string>;
+  getArtistColor: (artist: Artist) => string;
 }
 
 export function GenreInfo({
@@ -41,6 +42,7 @@ export function GenreInfo({
   onLinkedGenreClick,
   limitRelated = 5,
   onTopArtistClick,
+  getArtistColor,
     onBadDataSubmit,
     topArtists,
     getArtistImageByName,
@@ -397,6 +399,7 @@ export function GenreInfo({
                     <span className="text-md font-semibold">Top Artists</span>
                     <div className="flex flex-wrap items-center gap-1.5">
                     {topArtists.map((artist) => {
+                      const accent = getArtistColor(artist!);
                       const img = typeof artist.image === 'string' && artist.image.trim()
                         ? fixWikiImageURL(artist.image as string)
                         : undefined;
@@ -409,6 +412,10 @@ export function GenreInfo({
                           title={`${artist.listeners?.toLocaleString() ?? 0} listeners`}
                         >
                             <Button variant="ghost" size="sm" onClick={() => onTopArtistClick?.(artist)} className="cursor-pointer">
+                             <span
+                                className="inline-flex items-center justify-center rounded-full border-1 size-5"
+                                style={{ borderColor: accent }}
+                              >
                             {img ? (
                               <img
                                 src={img}
@@ -421,6 +428,7 @@ export function GenreInfo({
                                 {initial}
                               </span>
                             )}
+                            </span>
                               {artist.name}
                             </Button>
                         </Badge>

--- a/src/components/GenreInfo.tsx
+++ b/src/components/GenreInfo.tsx
@@ -420,11 +420,11 @@ export function GenreInfo({
                               <img
                                 src={img}
                                 alt={`${artist.name} avatar`}
-                                className="size-5 rounded-full object-cover"
+                                className="w-full h-full rounded-full object-cover"
                                 loading="lazy"
                               />
                             ) : (
-                              <span className="size-5 rounded-full bg-muted text-[10px] leading-4 text-center">
+                              <span className="w-full h-full rounded-full bg-muted text-[10px] leading-4 text-center">
                                 {initial}
                               </span>
                             )}

--- a/src/components/GenreInfo.tsx
+++ b/src/components/GenreInfo.tsx
@@ -410,7 +410,7 @@ export function GenreInfo({
                             key={artist.name}
                             name={artist.name}
                             imageUrl={img}
-                            accentColor={accent}
+                            genreColor={accent}
                             onClick={() =>onTopArtistClick?.(artist)}
                             title={`Go to ${artist.name}`}
                           />

--- a/src/components/GenreInfo.tsx
+++ b/src/components/GenreInfo.tsx
@@ -26,6 +26,7 @@ interface GenreInfoProps {
   onTopArtistClick?: (artist: Artist) => void;
   onBadDataSubmit: (id: string, reason: string, type: 'genre' | 'artist', hasFlag: boolean, details?: string) => Promise<boolean>;
   topArtists?: Artist[];
+  getArtistImageByName?: (name: string) => string | undefined;
 }
 
 export function GenreInfo({
@@ -41,6 +42,7 @@ export function GenreInfo({
   onTopArtistClick,
     onBadDataSubmit,
     topArtists,
+    getArtistImageByName,
 }: GenreInfoProps) {
   // On desktop, allow manual toggling of description; on mobile use snap state from panel
   const [desktopExpanded, setDesktopExpanded] = useState(true)
@@ -381,18 +383,34 @@ export function GenreInfo({
                   <div className="flex flex-col gap-2">
                     <span className="text-md font-semibold">Top Artists</span>
                     <div className="flex flex-wrap items-center gap-1.5">
-                    {topArtists.map((artist) => (
-                      <Badge
-                        key={artist.id}
-                        asChild
-                        variant="outline"
-                        title={`${artist.listeners?.toLocaleString() ?? 0} listeners`}
-                      >
-                        <Button variant="ghost" size="sm" onClick={() => onTopArtistClick?.(artist)} className="cursor-pointer">
-                          {artist.name}
-                        </Button>
-                      </Badge>
-                    ))}
+                    {topArtists.map((artist) => {
+                      const img = getArtistImageByName?.(artist.name);
+                      const initial = artist.name?.[0]?.toUpperCase() ?? '?';
+                      return (
+                        <Badge
+                          key={artist.id}
+                          asChild
+                          variant="outline"
+                          title={`${artist.listeners?.toLocaleString() ?? 0} listeners`}
+                        >
+                            <Button variant="ghost" size="sm" onClick={() => onTopArtistClick?.(artist)} className="cursor-pointer">
+                            {img ? (
+                              <img
+                                src={img}
+                                alt={`${artist.name} avatar`}
+                                className="w-4 h-4 rounded-full object-cover"
+                                loading="lazy"
+                              />
+                            ) : (
+                              <span className="w-4 h-4 rounded-full bg-muted text-[10px] leading-4 text-center">
+                                {initial}
+                              </span>
+                            )}
+                              {artist.name}
+                            </Button>
+                        </Badge>
+                      );
+                    })}
                     </div>
                 <Button
                   disabled={genreLoading}

--- a/src/components/GenreInfo.tsx
+++ b/src/components/GenreInfo.tsx
@@ -57,9 +57,9 @@ export function GenreInfo({
     if (!nodes || nodes.length === 0) return null
     const items = nodes.slice(0, limitRelated)
     return (
-      <div className="flex flex-col items-start gap-x-1.5 gap-3">
-        <span className="text-md text-muted-foreground">{label}:</span>
-        <div className='flex items-center gap-1.5 flex-wrap'>
+      <div className="flex flex-col items-start gap-2">
+        <span className="text-md font-medium text-muted-foreground">{label}:</span>
+        <div className='flex items-center gap-1 flex-wrap'>
           {items.map((node, i) => (
             <>
               {onLinkedGenreClick ? (
@@ -67,7 +67,7 @@ export function GenreInfo({
               ) : (
                 <span key={node.id}>{node.name}</span>
               )}
-              {i < items.length - 1 ? ' · ' : ''}
+              {/* {i < items.length - 1 ? ' · ' : ''} */}
             </>
           ))}
         </div>
@@ -432,8 +432,8 @@ export function GenreInfo({
               {/* Related */}
               {genreError && <p>Can’t find {selectedGenre?.name} 🤔</p>}
               {!genreError && (
-                <div className='flex flex-col gap-2'>
-                  <text className='text-md font-semibold'>Related</text>
+                <div className='flex flex-col gap-3'>
+                  <text className='text-md font-semibold'>Relationships</text>
                   <>
                     {relatedLine('Subgenre of', selectedGenre?.subgenre_of)}
                     {relatedLine('Subgenres', selectedGenre?.subgenres)}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -417,6 +417,3 @@ export const fixWikiImageURL = (url: string) => {
   }
   return url;
 }
-
-// Compute an artist accent color based on the first matching genre color.
-// Falls back to a neutral theme-based color when no genre mapping is available.

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -417,3 +417,6 @@ export const fixWikiImageURL = (url: string) => {
   }
   return url;
 }
+
+// Compute an artist accent color based on the first matching genre color.
+// Falls back to a neutral theme-based color when no genre mapping is available.


### PR DESCRIPTION
- ArtistInfo shows artist genres
- New component: ArtistBadge. Displays a clickable badge with the artist image or initial as leading avatar. Leading avatar border shows artist genre color
- New component: GenreBadge. Displays clickable badge with a small circle (dot) showing genre color.
- Refactored ArtistInfo and GenreInfo to use new components
- Updated getRootGenreFromTags to accept tags?: Tag[] | null and guard with const safeTags = tags ?? [] before filtering to fix crash “TypeError: null is not an object (evaluating 'tags.filter')” when rendering artist badges.