### PR TITLE
Mobile drawer de-jank and artist zoom

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -550,7 +550,7 @@ function App() {
                   </TabsList>
                 </Tabs>
                 { graph === 'artists' &&
-                <div className='flex gap-3'>
+                <div className='flex flex-col items-start sm:flex-row gap-3'>
                    <GenresFilter
                     key={initialGenreFilter.genre ? initialGenreFilter.genre.id : "none_selected"}
                     genres={[...genres, singletonParentGenre]}

--- a/src/components/ArtistBadge.tsx
+++ b/src/components/ArtistBadge.tsx
@@ -37,7 +37,7 @@ export default function ArtistBadge({
               loading="lazy"
             />
           ) : (
-            <span className="w-full h-full rounded-full bg-muted text-[10px] leading-4 text-center">
+            <span className="w-full h-full rounded-full bg-muted text-[10px] leading-5 text-center">
               {initial}
             </span>
           )}

--- a/src/components/ArtistInfo.tsx
+++ b/src/components/ArtistInfo.tsx
@@ -137,12 +137,10 @@ export function ArtistInfo({
           <>
             
 
-            {/* Scrolling Container: only scrollable on mobile when at max snap */}
+            {/* Scrolling Container: allow scrolling at all snaps (mobile + desktop) */}
             <div
               data-drawer-scroll
-              className={`w-full flex-1 min-h-0 flex flex-col gap-4 no-scrollbar pb-32 md:pb-16 
-                ${isDesktop ? 'overflow-y-auto' : (isAtMaxSnap ? 'overflow-y-auto' : 'overflow-hidden')}
-              `}
+              className={`w-full flex-1 min-h-0 flex flex-col gap-4 no-scrollbar pb-32 md:pb-16 overflow-y-auto`}
             >
               {/* Thumbnail */}
               <div

--- a/src/components/ArtistInfo.tsx
+++ b/src/components/ArtistInfo.tsx
@@ -137,8 +137,13 @@ export function ArtistInfo({
           <>
             
 
-            {/* Scrolling Container */}
-            <div data-drawer-scroll className="w-full flex-1 min-h-0 flex flex-col gap-4 overflow-y-auto no-scrollbar bp-32 md:pb16">
+            {/* Scrolling Container: only scrollable on mobile when at max snap */}
+            <div
+              data-drawer-scroll
+              className={`w-full flex-1 min-h-0 flex flex-col gap-4 no-scrollbar bp-32 md:pb16 
+                ${isDesktop ? 'overflow-y-auto' : (isAtMaxSnap ? 'overflow-y-auto' : 'overflow-hidden')}
+              `}
+            >
               {/* Thumbnail */}
               <div
                 className={`w-full overflow-hidden border-b border-sidebar-border rounded-lg h-[200px] shrink-0 flex-none ${

--- a/src/components/ArtistInfo.tsx
+++ b/src/components/ArtistInfo.tsx
@@ -131,7 +131,7 @@ export function ArtistInfo({
           : undefined
       }
     >
-      {({ isDesktop, isAtMaxSnap }) => {
+      {({ isDesktop, isAtMaxSnap, isAtMinSnap }) => {
         const isExpanded = isDesktop ? desktopExpanded : isAtMaxSnap;
         return (
           <>
@@ -140,7 +140,9 @@ export function ArtistInfo({
             {/* Scrolling Container: allow scrolling at all snaps (mobile + desktop) */}
             <div
               data-drawer-scroll
-              className={`w-full flex-1 min-h-0 flex flex-col gap-4 no-scrollbar pb-32 md:pb-16 overflow-y-auto`}
+              className={`w-full flex-1 min-h-0 flex flex-col gap-4 no-scrollbar pb-32 md:pb-16 
+                ${isDesktop ? 'overflow-y-auto' : (isAtMinSnap ? 'overflow-hidden' : 'overflow-y-auto')}
+              `}
             >
               {/* Thumbnail */}
               <div

--- a/src/components/ArtistInfo.tsx
+++ b/src/components/ArtistInfo.tsx
@@ -140,7 +140,7 @@ export function ArtistInfo({
             {/* Scrolling Container: only scrollable on mobile when at max snap */}
             <div
               data-drawer-scroll
-              className={`w-full flex-1 min-h-0 flex flex-col gap-4 no-scrollbar bp-32 md:pb16 
+              className={`w-full flex-1 min-h-0 flex flex-col gap-4 no-scrollbar pb-32 md:pb-16 
                 ${isDesktop ? 'overflow-y-auto' : (isAtMaxSnap ? 'overflow-y-auto' : 'overflow-hidden')}
               `}
             >

--- a/src/components/ArtistsForceGraph.tsx
+++ b/src/components/ArtistsForceGraph.tsx
@@ -140,7 +140,7 @@ const ArtistsForceGraph: React.FC<ArtistsForceGraphProps> = ({
             // Reheat the simulation when data or visibility changes
             fgRef.current.d3ReheatSimulation?.();
             const isMobile = window.matchMedia('(max-width: 640px)').matches
-            fgRef.current.zoom(isMobile ? 0.12 : 0.22)
+            fgRef.current.zoom(isMobile ? 0.12 : 0.18)
         }
     }, [preparedData, show]);
 

--- a/src/components/ArtistsForceGraph.tsx
+++ b/src/components/ArtistsForceGraph.tsx
@@ -139,6 +139,8 @@ const ArtistsForceGraph: React.FC<ArtistsForceGraphProps> = ({
 
             // Reheat the simulation when data or visibility changes
             fgRef.current.d3ReheatSimulation?.();
+            const isMobile = window.matchMedia('(max-width: 640px)').matches
+            fgRef.current.zoom(isMobile ? 0.12 : 0.22)
         }
     }, [preparedData, show]);
 

--- a/src/components/GenreInfo.tsx
+++ b/src/components/GenreInfo.tsx
@@ -203,7 +203,7 @@ export function GenreInfo({
           : undefined
       }
     >
-      {({ isDesktop, isAtMaxSnap }) => {
+      {({ isDesktop, isAtMaxSnap, isAtMinSnap }) => {
         const isExpanded = isDesktop ? desktopExpanded : isAtMaxSnap;
         return (
           <>
@@ -211,7 +211,9 @@ export function GenreInfo({
             {/* Scrolling Container: allow scrolling at all snaps (mobile + desktop) */}
             <div
               data-drawer-scroll
-              className={`w-full flex-1 min-h-0 flex flex-col gap-4 no-scrollbar pb-32 md:pb-16 overflow-y-auto`}
+              className={`w-full flex-1 min-h-0 flex flex-col gap-4 no-scrollbar pb-32 md:pb-16 
+                ${isDesktop ? 'overflow-y-auto' : (isAtMinSnap ? 'overflow-hidden' : 'overflow-y-auto')}
+              `}
             >
             
             {/* Thumbnail / Bento Carousel */}

--- a/src/components/GenreInfo.tsx
+++ b/src/components/GenreInfo.tsx
@@ -209,8 +209,13 @@ export function GenreInfo({
           <>
             
             {/* TODO: fix bug that's forcing us to use all this extra padding on the scrolling container */}
-            {/* Scrolling Container */}
-            <div data-drawer-scroll className='w-full flex-1 min-h-0 flex flex-col gap-4 overflow-y-auto no-scrollbar pb-32 md:pb-16'>
+            {/* Scrolling Container: only scrollable on mobile when at max snap */}
+            <div
+              data-drawer-scroll
+              className={`w-full flex-1 min-h-0 flex flex-col gap-4 no-scrollbar pb-32 md:pb-16 
+                ${isDesktop ? 'overflow-y-auto' : (isAtMaxSnap ? 'overflow-y-auto' : 'overflow-hidden')}
+              `}
+            >
             
             {/* Thumbnail / Bento Carousel */}
             <div className={`w-full overflow-hidden border-b border-sidebar-border rounded-lg h-[200px] shrink-0 flex-none

--- a/src/components/GenreInfo.tsx
+++ b/src/components/GenreInfo.tsx
@@ -208,13 +208,10 @@ export function GenreInfo({
         return (
           <>
             
-            {/* TODO: fix bug that's forcing us to use all this extra padding on the scrolling container */}
-            {/* Scrolling Container: only scrollable on mobile when at max snap */}
+            {/* Scrolling Container: allow scrolling at all snaps (mobile + desktop) */}
             <div
               data-drawer-scroll
-              className={`w-full flex-1 min-h-0 flex flex-col gap-4 no-scrollbar pb-32 md:pb-16 
-                ${isDesktop ? 'overflow-y-auto' : (isAtMaxSnap ? 'overflow-y-auto' : 'overflow-hidden')}
-              `}
+              className={`w-full flex-1 min-h-0 flex flex-col gap-4 no-scrollbar pb-32 md:pb-16 overflow-y-auto`}
             >
             
             {/* Thumbnail / Bento Carousel */}

--- a/src/components/ResponsiveDrawer.tsx
+++ b/src/components/ResponsiveDrawer.tsx
@@ -153,10 +153,8 @@ export function ResponsiveDrawer({
         if (next && !isDesktop) setActiveSnap(snapPoints[0] ?? 0.9);
       }}
       direction={isDesktop ? directionDesktop : "bottom"}
-      // When fully expanded and scrolled away from the top, restrict dragging to the handle
-      // to prevent accidental snap when the user intends to scroll.
-      // When not at max snap, allow drag from anywhere and disable content scrolling (handled by child).
-      handleOnly={!isDesktop && isAtMaxSnap && lockDragToHandleWhenScrolled && !isScrollAtTop}
+      // Disable content-driven snapping on mobile; drag via handle only
+      handleOnly={!isDesktop}
       dismissible={true}
       modal={false}
       {...(!isDesktop
@@ -178,9 +176,11 @@ export function ResponsiveDrawer({
           )}
           ref={cardRef}
         >
-          {!isDesktop && lockDragToHandleWhenScrolled && (
+          {!isDesktop && (
             <div className="w-full flex items-center justify-center select-none">
-              <DrawerHandle />
+              <DrawerHandle className="h-11 w-full flex items-center justify-center">
+                <span className="pointer-events-none block h-1 w-16 rounded-full bg-muted" />
+              </DrawerHandle>
             </div>
           )}
           {/* Header (mobile + desktop) inside panel */}

--- a/src/components/ResponsiveDrawer.tsx
+++ b/src/components/ResponsiveDrawer.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { Drawer, DrawerContent, DrawerHeader, DrawerTitle, DrawerDescription, DrawerClose, 
-  // DrawerHandle
+  DrawerHandle
  } from "@/components/ui/drawer";
 import { ChevronUp, ChevronDown, X } from 'lucide-react';
 import { Button } from "@/components/ui/button";
@@ -49,7 +49,7 @@ export function ResponsiveDrawer({
   contentClassName,
   bodyClassName,
   directionDesktop = "right",
-  snapPoints = [0.40, 0.9],
+  snapPoints = [0.50, 0.9],
   clickToCycleSnap = true,
   desktopQuery = "(min-width: 1200px)",
   showMobileHandle = false,
@@ -99,7 +99,8 @@ export function ResponsiveDrawer({
     }
     scrollElRef.current = el;
     const handleScroll = () => {
-      const atTop = (el?.scrollTop ?? 0) <= 0;
+      // Use a small tolerance to account for sub-pixel scroll values/bounce
+      const atTop = (el?.scrollTop ?? 0) <= 1;
       setIsScrollAtTop((prev) => (prev !== atTop ? atTop : prev));
     };
     // Initialize
@@ -152,7 +153,10 @@ export function ResponsiveDrawer({
         if (next && !isDesktop) setActiveSnap(snapPoints[0] ?? 0.9);
       }}
       direction={isDesktop ? directionDesktop : "bottom"}
-      handleOnly={!isDesktop && lockDragToHandleWhenScrolled && !isScrollAtTop}
+      // When fully expanded and scrolled away from the top, restrict dragging to the handle
+      // to prevent accidental snap when the user intends to scroll.
+      // When not at max snap, allow drag from anywhere and disable content scrolling (handled by child).
+      handleOnly={!isDesktop && isAtMaxSnap && lockDragToHandleWhenScrolled && !isScrollAtTop}
       dismissible={true}
       modal={false}
       {...(!isDesktop
@@ -176,7 +180,7 @@ export function ResponsiveDrawer({
         >
           {!isDesktop && lockDragToHandleWhenScrolled && (
             <div className="w-full flex items-center justify-center select-none">
-              {/* <DrawerHandle className="mt-1 mb-1" /> */}
+              <DrawerHandle />
             </div>
           )}
           {/* Header (mobile + desktop) inside panel */}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -72,7 +72,7 @@ function CommandInput({
       <CommandPrimitive.Input
         data-slot="command-input"
         className={cn(
-          "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+          "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-md sm:text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         {...props}
@@ -147,7 +147,7 @@ function CommandItem({
     <CommandPrimitive.Item
       data-slot="command-item"
       className={cn(
-        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-xl px-2 py-3 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default font-medium items-center gap-2 rounded-xl px-2 py-3 text-md sm:text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -132,6 +132,12 @@ function DrawerDescription({
   )
 }
 
+function DrawerHandle({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Handle>) {
+  return <DrawerPrimitive.Handle data-slot="drawer-handle" {...props} />
+}
+
 export {
   Drawer,
   DrawerPortal,
@@ -139,6 +145,7 @@ export {
   DrawerTrigger,
   DrawerClose,
   DrawerContent,
+  DrawerHandle,
   DrawerHeader,
   DrawerFooter,
   DrawerTitle,


### PR DESCRIPTION
- disabled scrolling in the min snap point. Let's test this out. I was running into a lot of bugs when scrolling was enabled. If it doesn't feel right, I can keep trying
- disabled cycle snap point on content drag. Also running into a lot of bugs here. Definitely doesn't feel as mobile-native but it's more reliable. again, if it sucks I can keep trying to make it work
- added initial zoom values for the artistgraph
- centered the text on the initial in the artistbadge in the case where there's no image
- filters transition to column layout on smaller screen. eventually, we'll have a more mobile-specific implementation
- command input to 16px on mobile