### PR TITLE
updated useArtists to be able to get top tracks on youtube

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,7 @@ import {
   primitiveArraysEqual,
   buildGenreTree,
   filterOutGenreTree,
-  fixWikiImageURL
+  fixWikiImageURL, appendYoutubeWatchURL
 } from "@/lib/utils";
 import ClusteringPanel from "@/components/ClusteringPanel";
 import { ModeToggle } from './components/ModeToggle';
@@ -100,6 +100,7 @@ function App() {
     artistsDataFlagError,
     totalArtistsInDB,
     topArtists,
+    fetchArtistTopTracksYT,
   } = useArtists(selectedGenreIDs, TOP_ARTISTS_TO_FETCH, artistNodeLimitType, artistNodeCount, isBeforeArtistLoad);
   const { similarArtists, similarArtistsLoading, similarArtistsError } = useSimilarArtists(selectedArtistNoGenre);
   const { theme } = useTheme();
@@ -177,6 +178,17 @@ function App() {
       setCanCreateSimilarArtistGraph(false);
     }
   }, [similarArtists]);
+
+  // code to test the new endpoint, will remove when ui component is implemented
+  useEffect(() => {
+    testFetchArtistTopTracks();
+  }, [selectedArtist]);
+  const testFetchArtistTopTracks = async () => {
+    if (selectedArtist) {
+      const link = await fetchArtistTopTracksYT(selectedArtist.id, selectedArtist.name);
+      if (link) console.log(appendYoutubeWatchURL(link[0]));
+    }
+  }
 
   const setArtistFromName = (name: string) => {
     const artist = currentArtists.find((a) => a.name === name);

--- a/src/hooks/useArtists.tsx
+++ b/src/hooks/useArtists.tsx
@@ -114,6 +114,19 @@ const useArtists = (genreIDs: string[], topAmount = TOP_ARTISTS_TO_FETCH, filter
         return success;
     }
 
+    const fetchArtistTopTracksYT = async (artistID: string, artistName: string) => {
+        try {
+            const response = await axios.get(`${url}/artists/toptracks/${artistID}/${artistName}`);
+            const topTracks: string[] = response.data;
+            return topTracks;
+        } catch (err) {
+            if (err instanceof AxiosError) {
+                setArtistsError(err);
+            }
+        }
+        return [];
+    }
+
     return {
         artists,
         artistsLoading,
@@ -126,6 +139,7 @@ const useArtists = (genreIDs: string[], topAmount = TOP_ARTISTS_TO_FETCH, filter
         totalArtistsInDB,
         topArtists,
         fetchMultipleGenresArtists,
+        fetchArtistTopTracksYT,
     };
 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -375,3 +375,7 @@ export const getRootGenreOfChild = (genre: Genre, genres: Genre[], genreClusterM
     });
   }
 }
+
+export const appendYoutubeWatchURL = (ytID: string) => {
+  return `https://www.youtube.com/watch?v=${ytID}`;
+}


### PR DESCRIPTION
- useArtists can fetch an artist's top tracks on youtube
- Uses last.fm top tracks and scrapes the youtube links from those pages
- If lacking youtube links on last.fm, it searches using the youtube api, not as reliable but works most of the time
- Should be easy to plug these youtube ids into an embedded player of some sort
- for now there's a console.log that prints the top video when an artist is selected
- update local server to use, also need a `YOUTUBE_API_KEY` in the .env to use locally