### PR TITLE
Zoom buttons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -150,7 +150,7 @@ function App() {
     localStorage.setItem('dagMode', JSON.stringify(dagMode));
   }, [dagMode]);
 
-  // Zoom hotkeys only (+ / -)
+  // Zoom hotkeys (+ / -)
   useHotkeys({
     onZoomIn: () => {
       const ref = graph === 'genres' ? genresGraphRef.current : artistsGraphRef.current;
@@ -799,7 +799,7 @@ function App() {
                     computeArtistColor={getArtistColor}
                 />
 
-            <div className='z-20 fixed bottom-16 right-4'>
+            <div className='z-20 fixed bottom-16 right-3'>
               <ZoomButtons
                 onZoomIn={() => {
                   const ref = graph === 'genres' ? genresGraphRef.current : artistsGraphRef.current;
@@ -811,7 +811,7 @@ function App() {
                 }}
               />
             </div>
-          {!isMobile && <div className='z-20 fixed bottom-4 right-4'>
+          {!isMobile && <div className='z-20 fixed bottom-4 right-3'>
             <NodeLimiter
                 totalNodes={genres.length}
                 nodeType={'genres'}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -789,17 +789,19 @@ function App() {
                     computeArtistColor={getArtistColor}
                 />
 
+            <div className='z-20 fixed bottom-16 right-4'>
+              <ZoomButtons
+                onZoomIn={() => {
+                  const ref = graph === 'genres' ? genresGraphRef.current : artistsGraphRef.current;
+                  ref?.zoomIn();
+                }}
+                onZoomOut={() => {
+                  const ref = graph === 'genres' ? genresGraphRef.current : artistsGraphRef.current;
+                  ref?.zoomOut();
+                }}
+              />
+            </div>
           {!isMobile && <div className='z-20 fixed bottom-4 right-4'>
-            <ZoomButtons
-              onZoomIn={() => {
-                const ref = graph === 'genres' ? genresGraphRef.current : artistsGraphRef.current;
-                ref?.zoomIn();
-              }}
-              onZoomOut={() => {
-                const ref = graph === 'genres' ? genresGraphRef.current : artistsGraphRef.current;
-                ref?.zoomOut();
-              }}
-            />
             <NodeLimiter
                 totalNodes={genres.length}
                 nodeType={'genres'}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,6 +54,7 @@ import {
   TOP_ARTISTS_TO_FETCH, EMPTY_GENRE_FILTER_OBJECT, SINGLETON_PARENT_GENRE, GENRE_FILTER_CLUSTER_MODE
 } from "@/constants";
 import RhizomeLogo from "@/components/RhizomeLogo";
+import ZoomButtons from '@/components/ZoomButtons';
 
 function SidebarLogoTrigger() {
   const { toggleSidebar } = useSidebar()
@@ -784,6 +785,7 @@ function App() {
                 />
 
           {!isMobile && <div className='z-20 fixed bottom-4 right-4'>
+            <ZoomButtons />
             <NodeLimiter
                 totalNodes={genres.length}
                 nodeType={'genres'}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,6 +55,7 @@ import {
 } from "@/constants";
 import RhizomeLogo from "@/components/RhizomeLogo";
 import ZoomButtons from '@/components/ZoomButtons';
+import useHotkeys from '@/hooks/useHotkeys';
 
 function SidebarLogoTrigger() {
   const { toggleSidebar } = useSidebar()
@@ -149,11 +150,22 @@ function App() {
     localStorage.setItem('dagMode', JSON.stringify(dagMode));
   }, [dagMode]);
 
-  // Custom escape key functionality
+  // Zoom hotkeys only (+ / -)
+  useHotkeys({
+    onZoomIn: () => {
+      const ref = graph === 'genres' ? genresGraphRef.current : artistsGraphRef.current;
+      ref?.zoomIn?.();
+    },
+    onZoomOut: () => {
+      const ref = graph === 'genres' ? genresGraphRef.current : artistsGraphRef.current;
+      ref?.zoomOut?.();
+    },
+  }, [graph]);
+
+  // Restore standalone Escape handling (deselect)
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
-        // Prefer logical selection state over UI visibility flags
         if (graph === 'genres' && selectedGenres.length){
           deselectGenre();
           return;
@@ -165,21 +177,19 @@ function App() {
       }
     };
     window.addEventListener('keydown', handleKeyDown);
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [selectedArtist, selectedGenres]);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [graph, selectedArtist, selectedGenres]);
 
-  // Custom command-K key functionality for search
+  // Restore Cmd/Ctrl+K handling (search)
   useEffect(() => {
     const down = (e: KeyboardEvent) => {
-      if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
+      if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
         setSearchOpen((prev) => !prev);
       }
-    }
-    document.addEventListener("keydown", down);
-    return () => document.removeEventListener("keydown", down)
+    };
+    document.addEventListener('keydown', down);
+    return () => document.removeEventListener('keydown', down);
   }, []);
 
   // Sets current artists/links shown in the graph when artists are fetched from the DB

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,6 +69,9 @@ function SidebarLogoTrigger() {
 }
 
 function App() {
+  type GraphHandle = { zoomIn: () => void; zoomOut: () => void; zoomTo: (k: number, ms?: number) => void; getZoom: () => number }
+  const genresGraphRef = useRef<GraphHandle | null>(null);
+  const artistsGraphRef = useRef<GraphHandle | null>(null);
   const [selectedGenres, setSelectedGenres] = useState<Genre[]>([]);
   const selectedGenreIDs = useMemo(() => {
     return selectedGenres.map(genre => genre.id);
@@ -763,6 +766,7 @@ function App() {
                   </Button>
           </motion.div>
                 <GenresForceGraph
+                  ref={genresGraphRef as any}
                   graphData={currentGenres}
                   onNodeClick={onGenreNodeClick}
                   loading={genresLoading}
@@ -773,6 +777,7 @@ function App() {
                   selectedGenreId={selectedGenres[0]?.id}
                 />
                 <ArtistsForceGraph
+                    ref={artistsGraphRef as any}
                     artists={currentArtists}
                     artistLinks={currentArtistLinks}
                     loading={artistsLoading}
@@ -785,7 +790,16 @@ function App() {
                 />
 
           {!isMobile && <div className='z-20 fixed bottom-4 right-4'>
-            <ZoomButtons />
+            <ZoomButtons
+              onZoomIn={() => {
+                const ref = graph === 'genres' ? genresGraphRef.current : artistsGraphRef.current;
+                ref?.zoomIn();
+              }}
+              onZoomOut={() => {
+                const ref = graph === 'genres' ? genresGraphRef.current : artistsGraphRef.current;
+                ref?.zoomOut();
+              }}
+            />
             <NodeLimiter
                 totalNodes={genres.length}
                 nodeType={'genres'}

--- a/src/components/ArtistsForceGraph.tsx
+++ b/src/components/ArtistsForceGraph.tsx
@@ -90,12 +90,12 @@ const ArtistsForceGraph = forwardRef<GraphHandle, ArtistsForceGraphProps>(({
     useImperativeHandle(ref, () => ({
         zoomIn: () => {
             const cur = zoomRef.current || 1;
-            const target = Math.min(20, cur * 1.2);
+            const target = Math.min(20, cur * 2.2);
             fgRef.current?.zoom?.(target, 400);
         },
         zoomOut: () => {
             const cur = zoomRef.current || 1;
-            const target = Math.max(0.03, cur / 1.2);
+            const target = Math.max(0.03, cur / 2.2);
             fgRef.current?.zoom?.(target, 400);
         },
         zoomTo: (k: number, ms = 400) => {

--- a/src/components/ArtistsForceGraph.tsx
+++ b/src/components/ArtistsForceGraph.tsx
@@ -1,10 +1,17 @@
 import {Artist, NodeLink} from "@/types";
-import React, {useEffect, useMemo, useRef, useState} from "react";
+import React, {forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState} from "react";
 import ForceGraph, {GraphData, ForceGraphMethods} from "react-force-graph-2d";
 import { Loading } from "./Loading";
 import { useTheme } from "next-themes";
 import { drawCircleNode, drawLabelBelow, labelAlphaForZoom, collideRadiusForNode, DEFAULT_LABEL_FADE_START, DEFAULT_LABEL_FADE_END, LABEL_FONT_SIZE } from "@/lib/graphStyle";
 import * as d3 from 'd3-force';
+
+export type GraphHandle = {
+    zoomIn: () => void;
+    zoomOut: () => void;
+    zoomTo: (k: number, ms?: number) => void;
+    getZoom: () => number;
+}
 
 interface ArtistsForceGraphProps {
     artists: Artist[];
@@ -34,7 +41,7 @@ interface ArtistsForceGraphProps {
     strokeMinPx?: number;
 }
 
-const ArtistsForceGraph: React.FC<ArtistsForceGraphProps> = ({
+const ArtistsForceGraph = forwardRef<GraphHandle, ArtistsForceGraphProps>(({ 
     artists,
     artistLinks,
     onNodeClick,
@@ -50,7 +57,7 @@ const ArtistsForceGraph: React.FC<ArtistsForceGraphProps> = ({
     maxLinksToShow = 6000,
     minLabelPx = 8,
     strokeMinPx = 13,
-}) => {
+}, ref) => {
     const { theme } = useTheme();
 
     const preparedData: GraphData<Artist, NodeLink> = useMemo(() => {
@@ -78,6 +85,25 @@ const ArtistsForceGraph: React.FC<ArtistsForceGraphProps> = ({
     const prevHoveredRef = useRef<string | undefined>(undefined);
     const yOffsetByIdRef = useRef<Map<string, number>>(new Map());
     const animRafRef = useRef<number | null>(null);
+
+    // Expose simple zoom API to parent
+    useImperativeHandle(ref, () => ({
+        zoomIn: () => {
+            const cur = zoomRef.current || 1;
+            const target = Math.min(20, cur * 1.2);
+            fgRef.current?.zoom?.(target, 400);
+        },
+        zoomOut: () => {
+            const cur = zoomRef.current || 1;
+            const target = Math.max(0.03, cur / 1.2);
+            fgRef.current?.zoom?.(target, 400);
+        },
+        zoomTo: (k: number, ms = 400) => {
+            const target = Math.max(0.03, Math.min(20, k));
+            fgRef.current?.zoom?.(target, ms);
+        },
+        getZoom: () => zoomRef.current || 1,
+    }), []);
 
     // Animate label y-offset on hover using simple easing
     useEffect(() => {
@@ -306,6 +332,6 @@ const ArtistsForceGraph: React.FC<ArtistsForceGraphProps> = ({
             }}
         />)
     )
-}
+});
 
 export default ArtistsForceGraph;

--- a/src/components/GenresForceGraph.tsx
+++ b/src/components/GenresForceGraph.tsx
@@ -42,12 +42,12 @@ const GenresForceGraph = forwardRef<GraphHandle, GenresForceGraphProps>(({ graph
     useImperativeHandle(ref, () => ({
         zoomIn: () => {
             const cur = zoomRef.current || 1;
-            const target = Math.min(20, cur * 1.2);
+            const target = Math.min(20, cur * 2.2);
             fgRef.current?.zoom?.(target, 400);
         },
         zoomOut: () => {
             const cur = zoomRef.current || 1;
-            const target = Math.max(0.03, cur / 1.2);
+            const target = Math.max(0.03, cur / 2.2);
             fgRef.current?.zoom?.(target, 400);
         },
         zoomTo: (k: number, ms = 400) => {

--- a/src/components/GenresForceGraph.tsx
+++ b/src/components/GenresForceGraph.tsx
@@ -1,5 +1,5 @@
 import {Genre, GenreClusterMode, GenreGraphData, NodeLink} from "@/types";
-import React, {useEffect, useRef, useMemo, useState} from "react";
+import React, {forwardRef, useEffect, useImperativeHandle, useRef, useMemo, useState} from "react";
 import ForceGraph, {ForceGraphMethods, GraphData, NodeObject} from "react-force-graph-2d";
 import {Loading} from "./Loading";
 import {forceCollide} from 'd3-force';
@@ -7,6 +7,13 @@ import * as d3 from 'd3-force';
 import { useTheme } from "next-themes";
 import { CLUSTER_COLORS } from "@/constants";
 import { drawCircleNode, drawLabelBelow, labelAlphaForZoom, collideRadiusForNode, LABEL_FONT_SIZE } from "@/lib/graphStyle";
+
+export type GraphHandle = {
+    zoomIn: () => void;
+    zoomOut: () => void;
+    zoomTo: (k: number, ms?: number) => void;
+    getZoom: () => number;
+}
 
 interface GenresForceGraphProps {
     graphData?: GenreGraphData;
@@ -22,7 +29,7 @@ interface GenresForceGraphProps {
 
 // Styling shared via graphStyle utils
 
-const GenresForceGraph: React.FC<GenresForceGraphProps> = ({ graphData, onNodeClick, loading, show, dag, clusterModes, colorMap: externalColorMap, selectedGenreId }) => {
+const GenresForceGraph = forwardRef<GraphHandle, GenresForceGraphProps>(({ graphData, onNodeClick, loading, show, dag, clusterModes, colorMap: externalColorMap, selectedGenreId }, ref) => {
     const fgRef = useRef<ForceGraphMethods<Genre, NodeLink> | undefined>(undefined);
     const zoomRef = useRef<number>(1);
     const [hoveredId, setHoveredId] = useState<string | undefined>(undefined);
@@ -30,6 +37,25 @@ const GenresForceGraph: React.FC<GenresForceGraphProps> = ({ graphData, onNodeCl
     const yOffsetByIdRef = useRef<Map<string, number>>(new Map());
     const animRafRef = useRef<number | null>(null);
     const { theme } = useTheme();
+
+    // Expose simple zoom API to parent
+    useImperativeHandle(ref, () => ({
+        zoomIn: () => {
+            const cur = zoomRef.current || 1;
+            const target = Math.min(20, cur * 1.2);
+            fgRef.current?.zoom?.(target, 400);
+        },
+        zoomOut: () => {
+            const cur = zoomRef.current || 1;
+            const target = Math.max(0.03, cur / 1.2);
+            fgRef.current?.zoom?.(target, 400);
+        },
+        zoomTo: (k: number, ms = 400) => {
+            const target = Math.max(0.03, Math.min(20, k));
+            fgRef.current?.zoom?.(target, ms);
+        },
+        getZoom: () => zoomRef.current || 1,
+    }), []);
 
     const preparedData: GraphData<Genre, NodeLink> = useMemo(() => {
         if (!graphData) return { nodes: [], links: [] };
@@ -292,6 +318,6 @@ const GenresForceGraph: React.FC<GenresForceGraphProps> = ({ graphData, onNodeCl
             nodePointerAreaPaint={nodePointerAreaPaint}
         />
     )
-}
+});
 
 export default GenresForceGraph;

--- a/src/components/ZoomButtons.tsx
+++ b/src/components/ZoomButtons.tsx
@@ -8,17 +8,7 @@ type ZoomButtonsProps = {
 
 const ZoomButtons: React.FC<ZoomButtonsProps> = ({ onZoomIn, onZoomOut }) => {
   return (
-    <div className='flex-col w-fit -space-x-px rounded-full overflow-clip border rtl:space-x-reverse'>
-      <Button
-        variant='outline'
-        size='icon'
-        className='rounded-none border-none shadow-none focus-visible:z-10'
-        onClick={onZoomOut}
-        aria-label='Zoom out'
-      >
-        <ZoomOutIcon />
-        <span className='sr-only'>Zoom out</span>
-      </Button>
+    <div className='flex flex-col w-fit -space-x-px rounded-full overflow-clip border rtl:space-x-reverse'>
       <Button
         variant='outline'
         size='icon'
@@ -28,6 +18,16 @@ const ZoomButtons: React.FC<ZoomButtonsProps> = ({ onZoomIn, onZoomOut }) => {
       >
         <ZoomInIcon />
         <span className='sr-only'>Zoom in</span>
+      </Button>
+      <Button
+        variant='outline'
+        size='icon'
+        className='rounded-none border-none shadow-none focus-visible:z-10'
+        onClick={onZoomOut}
+        aria-label='Zoom out'
+      >
+        <ZoomOutIcon />
+        <span className='sr-only'>Zoom out</span>
       </Button>
     </div>
   )

--- a/src/components/ZoomButtons.tsx
+++ b/src/components/ZoomButtons.tsx
@@ -1,43 +1,30 @@
-import { useState } from 'react'
 import { ZoomInIcon, ZoomOutIcon } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 
-const ZoomButtons = () => {
-  const [zoom, setZoom] = useState(95)
+type ZoomButtonsProps = {
+  onZoomIn?: () => void
+  onZoomOut?: () => void
+}
 
-  const handleZoomIn = () => {
-    if (zoom < 100) {
-      setZoom(zoom + 5)
-    }
-  }
-
-  const handleZoomOut = () => {
-    if (zoom > 0) {
-      setZoom(zoom - 5)
-    }
-  }
-
+const ZoomButtons: React.FC<ZoomButtonsProps> = ({ onZoomIn, onZoomOut }) => {
   return (
     <div className='flex-col w-fit -space-x-px rounded-full overflow-clip border rtl:space-x-reverse'>
       <Button
         variant='outline'
         size='icon'
         className='rounded-none border-none shadow-none focus-visible:z-10'
-        onClick={handleZoomOut}
-        disabled={zoom === 0}
+        onClick={onZoomOut}
+        aria-label='Zoom out'
       >
         <ZoomOutIcon />
         <span className='sr-only'>Zoom out</span>
       </Button>
-      {/* <span className='bg-background dark:border-input dark:bg-input/30 flex items-center border px-3 text-sm font-medium'>
-        {`${zoom}%`}
-      </span> */}
       <Button
         variant='outline'
         size='icon'
         className='rounded-none border-none border-l shadow-none focus-visible:z-10'
-        onClick={handleZoomIn}
-        disabled={zoom === 100}
+        onClick={onZoomIn}
+        aria-label='Zoom in'
       >
         <ZoomInIcon />
         <span className='sr-only'>Zoom in</span>

--- a/src/components/ZoomButtons.tsx
+++ b/src/components/ZoomButtons.tsx
@@ -8,11 +8,11 @@ type ZoomButtonsProps = {
 
 const ZoomButtons: React.FC<ZoomButtonsProps> = ({ onZoomIn, onZoomOut }) => {
   return (
-    <div className='flex flex-col w-fit -space-x-px rounded-full overflow-clip border rtl:space-x-reverse'>
+    <div className='flex flex-col w-fit border overflow-hidden rounded-full bg-background/80 shadow-xs focus-within:ring-2 focus-within:ring-ring/40 focus-within:ring-offset-2 focus-within:ring-offset-background'>
       <Button
         variant='outline'
         size='icon'
-        className='rounded-none border-none border-l shadow-none focus-visible:z-10'
+        className='rounded-none border-0 shadow-none focus:outline-none focus-visible:outline-none focus-visible:ring-0 focus-visible:shadow-none focus-visible:border-transparent first:rounded-t-full'
         onClick={onZoomIn}
         aria-label='Zoom in'
         title='Zoom in'
@@ -23,7 +23,7 @@ const ZoomButtons: React.FC<ZoomButtonsProps> = ({ onZoomIn, onZoomOut }) => {
       <Button
         variant='outline'
         size='icon'
-        className='rounded-none border-none shadow-none focus-visible:z-10'
+        className='rounded-none border-0 shadow-none focus:outline-none focus-visible:outline-none focus-visible:ring-0 focus-visible:shadow-none focus-visible:border-transparent last:rounded-b-full'
         onClick={onZoomOut}
         aria-label='Zoom out'
         title='Zoom out'

--- a/src/components/ZoomButtons.tsx
+++ b/src/components/ZoomButtons.tsx
@@ -15,6 +15,7 @@ const ZoomButtons: React.FC<ZoomButtonsProps> = ({ onZoomIn, onZoomOut }) => {
         className='rounded-none border-none border-l shadow-none focus-visible:z-10'
         onClick={onZoomIn}
         aria-label='Zoom in'
+        title='Zoom in'
       >
         <ZoomInIcon />
         <span className='sr-only'>Zoom in</span>
@@ -25,6 +26,7 @@ const ZoomButtons: React.FC<ZoomButtonsProps> = ({ onZoomIn, onZoomOut }) => {
         className='rounded-none border-none shadow-none focus-visible:z-10'
         onClick={onZoomOut}
         aria-label='Zoom out'
+        title='Zoom out'
       >
         <ZoomOutIcon />
         <span className='sr-only'>Zoom out</span>

--- a/src/components/ZoomButtons.tsx
+++ b/src/components/ZoomButtons.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react'
+import { ZoomInIcon, ZoomOutIcon } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+const ZoomButtons = () => {
+  const [zoom, setZoom] = useState(95)
+
+  const handleZoomIn = () => {
+    if (zoom < 100) {
+      setZoom(zoom + 5)
+    }
+  }
+
+  const handleZoomOut = () => {
+    if (zoom > 0) {
+      setZoom(zoom - 5)
+    }
+  }
+
+  return (
+    <div className='flex-col w-fit -space-x-px rounded-full overflow-clip border rtl:space-x-reverse'>
+      <Button
+        variant='outline'
+        size='icon'
+        className='rounded-none border-none shadow-none focus-visible:z-10'
+        onClick={handleZoomOut}
+        disabled={zoom === 0}
+      >
+        <ZoomOutIcon />
+        <span className='sr-only'>Zoom out</span>
+      </Button>
+      {/* <span className='bg-background dark:border-input dark:bg-input/30 flex items-center border px-3 text-sm font-medium'>
+        {`${zoom}%`}
+      </span> */}
+      <Button
+        variant='outline'
+        size='icon'
+        className='rounded-none border-none border-l shadow-none focus-visible:z-10'
+        onClick={handleZoomIn}
+        disabled={zoom === 100}
+      >
+        <ZoomInIcon />
+        <span className='sr-only'>Zoom in</span>
+      </Button>
+    </div>
+  )
+}
+
+export default ZoomButtons

--- a/src/hooks/useHotkeys.ts
+++ b/src/hooks/useHotkeys.ts
@@ -1,0 +1,44 @@
+import { useEffect } from 'react';
+
+export type UseZoomHotkeysOptions = {
+  onZoomIn: () => void;
+  onZoomOut: () => void;
+  enabled?: boolean;
+};
+
+function isEditableTarget(el: EventTarget | null) {
+  const t = el as HTMLElement | null;
+  if (!t) return false;
+  const tag = (t.tagName || '').toLowerCase();
+  return tag === 'input' || tag === 'textarea' || tag === 'select' || t.isContentEditable === true;
+}
+
+export default function useHotkeys(opts: UseZoomHotkeysOptions, deps: any[] = []) {
+  const { onZoomIn, onZoomOut, enabled = true } = opts;
+  useEffect(() => {
+    if (!enabled) return;
+    const handler = (e: KeyboardEvent) => {
+      if (isEditableTarget(e.target)) return;
+
+      // Avoid clashing with browser zoom
+      if (e.ctrlKey || e.metaKey) return;
+
+      const k = e.key;
+      const code = e.code;
+
+      if (k === '=' || k === '+' || code === 'NumpadAdd') {
+        e.preventDefault();
+        onZoomIn();
+        return;
+      }
+      if (k === '-' || k === '_' || code === 'NumpadSubtract') {
+        e.preventDefault();
+        onZoomOut();
+        return;
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+}


### PR DESCRIPTION
**Changes**
- Let both graph components expose simple zoomIn, zoomOut, zoomTo, and getZoom methods so the parent screen can control them.
- Added  ZoomButtons component plus a useHotkeys hook that ties +/- keys to whichever graph is visible.
- Updated App to keep refs to the graphs, hook up the new controls, and show the zoom buttons on screen.
- Added a new hook "useHotKeys" for centralizing hotkeys. Only added zoomies so far