### PR TITLE
added authoverlay, reset app to MobileAppBar, graph resizing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -708,8 +708,8 @@ function App() {
       >
         <SidebarLogoTrigger />
         <Toaster />
-        <Gradient />
-        <div className="fixed inset-0 overflow-hidden no-scrollbar">
+        <div className="fixed inset-0 z-0 overflow-hidden no-scrollbar">
+          <Gradient />
           <motion.div
             className={
               "fixed top-0 left-0 z-50 pt-2 pl-3 flex justify-left flex-col items-start md:flex-row gap-3"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,6 +74,7 @@ function App() {
   type GraphHandle = { zoomIn: () => void; zoomOut: () => void; zoomTo: (k: number, ms?: number) => void; getZoom: () => number }
   const genresGraphRef = useRef<GraphHandle | null>(null);
   const artistsGraphRef = useRef<GraphHandle | null>(null);
+  const [viewport, setViewport] = useState<{ width: number; height: number }>({ width: 0, height: 0 });
   const [selectedGenres, setSelectedGenres] = useState<Genre[]>([]);
   const selectedGenreIDs = useMemo(() => {
     return selectedGenres.map(genre => genre.id);
@@ -134,6 +135,14 @@ function App() {
   const playRequest = useRef(0);
   const [playerSource, setPlayerSource] = useState<'artist' | 'genre' | undefined>(undefined);
   const [playerEntityName, setPlayerEntityName] = useState<string | undefined>(undefined);
+
+  // Track window size and pass to ForceGraph for reliable resizing
+  useEffect(() => {
+    const update = () => setViewport({ width: window.innerWidth, height: window.innerHeight });
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, []);
 
   const singletonParentGenre = useMemo(() => {
     return {
@@ -700,7 +709,7 @@ function App() {
         <SidebarLogoTrigger />
         <Toaster />
         <Gradient />
-        <div className="relative h-screen w-screen overflow-hidden no-scrollbar">
+        <div className="fixed inset-0 overflow-hidden no-scrollbar">
           <motion.div
             className={
               "fixed top-0 left-0 z-50 pt-2 pl-3 flex justify-left flex-col items-start md:flex-row gap-3"
@@ -786,6 +795,8 @@ function App() {
                   clusterModes={genreClusterMode}
                   colorMap={genreColorMap}
                   selectedGenreId={selectedGenres[0]?.id}
+                  width={viewport.width || undefined}
+                  height={viewport.height || undefined}
                 />
                 <ArtistsForceGraph
                     ref={artistsGraphRef as any}
@@ -798,6 +809,8 @@ function App() {
                         (graph === "artists" || graph === "similarArtists") && !artistsError
                     }
                     computeArtistColor={getArtistColor}
+                    width={viewport.width || undefined}
+                    height={viewport.height || undefined}
                 />
 
             <div className='z-20 fixed bottom-[52%] sm:bottom-16 right-3'>

--- a/src/components/AppSideBar.tsx
+++ b/src/components/AppSideBar.tsx
@@ -115,7 +115,7 @@ export function AppSidebar({ children, onClick, selectedGenre, setSearchOpen, on
                       </SidebarMenuItem> */}
                     <SidebarMenuItem>
                       <SidebarMenuButton asChild isActive={true} size="xl">
-                        <button>
+                        <button onClick={resetAppState}>
                           <Telescope />
                           <span>Explore</span>
                         </button>
@@ -171,6 +171,7 @@ export function AppSidebar({ children, onClick, selectedGenre, setSearchOpen, on
         graph={graph}
         onGraphChange={onGraphChange}
         onOpenSearch={() => setSearchOpen(true)}
+        resetAppState={resetAppState}
       />
     </>
   )

--- a/src/components/ArtistsForceGraph.tsx
+++ b/src/components/ArtistsForceGraph.tsx
@@ -3,7 +3,7 @@ import React, {forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useS
 import ForceGraph, {GraphData, ForceGraphMethods} from "react-force-graph-2d";
 import { Loading } from "./Loading";
 import { useTheme } from "next-themes";
-import { drawCircleNode, drawLabelBelow, labelAlphaForZoom, collideRadiusForNode, DEFAULT_LABEL_FADE_START, DEFAULT_LABEL_FADE_END, LABEL_FONT_SIZE } from "@/lib/graphStyle";
+import { drawCircleNode, drawLabelBelow, labelAlphaForZoom, collideRadiusForNode, DEFAULT_LABEL_FADE_START, DEFAULT_LABEL_FADE_END, LABEL_FONT_SIZE, applyMobileDrawerYOffset } from "@/lib/graphStyle";
 import * as d3 from 'd3-force';
 
 export type GraphHandle = {
@@ -195,7 +195,10 @@ const ArtistsForceGraph = forwardRef<GraphHandle, ArtistsForceGraphProps>(({
         const centerToNode = () => {
             const x = node.x ?? 0;
             const y = node.y ?? 0;
-            fgRef.current!.centerAt(x, y, 600);
+            const isMobile = window.matchMedia('(max-width: 640px)').matches;
+            const k = zoomRef.current || 1;
+            const yAdjusted = applyMobileDrawerYOffset(y, k, isMobile);
+            fgRef.current!.centerAt(x, yAdjusted, 600);
             // Choose a friendly zoom level
             const targetK = Math.max(0.8, Math.min(2.2, (zoomRef.current || 1) < 1 ? 1.2 : zoomRef.current));
             fgRef.current!.zoom(targetK, 600);

--- a/src/components/ArtistsForceGraph.tsx
+++ b/src/components/ArtistsForceGraph.tsx
@@ -39,6 +39,9 @@ interface ArtistsForceGraphProps {
     minLabelPx?: number;
     // Minimum size at which to draw the halo stroke. Default 13.
     strokeMinPx?: number;
+    // Explicit size for the canvas (viewport)
+    width?: number;
+    height?: number;
 }
 
 const ArtistsForceGraph = forwardRef<GraphHandle, ArtistsForceGraphProps>(({ 
@@ -57,6 +60,8 @@ const ArtistsForceGraph = forwardRef<GraphHandle, ArtistsForceGraphProps>(({
     maxLinksToShow = 6000,
     minLabelPx = 8,
     strokeMinPx = 13,
+    width,
+    height,
 }, ref) => {
     const { theme } = useTheme();
 
@@ -244,12 +249,14 @@ const ArtistsForceGraph = forwardRef<GraphHandle, ArtistsForceGraphProps>(({
         return colorById.get(artist.id) || (theme === 'dark' ? '#8a80ff' : '#4a4a4a');
     };
 
-    return !show ? null : loading ? (<div className="flex-1 h-[calc(100vh-104px)] w-full">
+    return !show ? null : loading ? (<div className="flex-1 w-full" style={{ height: height ?? '100%' }}>
         <Loading />
     </div>) : (
         (<ForceGraph
             ref={fgRef as any}
             graphData={preparedData}
+            width={width}
+            height={height}
             // Always show links per request
             linkVisibility={() => true}
             linkColor={(l: any) => {

--- a/src/components/GenresForceGraph.tsx
+++ b/src/components/GenresForceGraph.tsx
@@ -6,7 +6,7 @@ import {forceCollide} from 'd3-force';
 import * as d3 from 'd3-force';
 import { useTheme } from "next-themes";
 import { CLUSTER_COLORS } from "@/constants";
-import { drawCircleNode, drawLabelBelow, labelAlphaForZoom, collideRadiusForNode, LABEL_FONT_SIZE } from "@/lib/graphStyle";
+import { drawCircleNode, drawLabelBelow, labelAlphaForZoom, collideRadiusForNode, LABEL_FONT_SIZE, applyMobileDrawerYOffset } from "@/lib/graphStyle";
 
 export type GraphHandle = {
     zoomIn: () => void;
@@ -220,7 +220,10 @@ const GenresForceGraph = forwardRef<GraphHandle, GenresForceGraphProps>(({ graph
         const centerToNode = () => {
             const x = node.x ?? 0;
             const y = node.y ?? 0;
-            fgRef.current!.centerAt(x, y, 600);
+            const isMobile = window.matchMedia('(max-width: 640px)').matches;
+            const k = zoomRef.current || 1;
+            const yAdjusted = applyMobileDrawerYOffset(y, k, isMobile);
+            fgRef.current!.centerAt(x, yAdjusted, 600);
             const targetK = Math.max(0.7, Math.min(2.0, (zoomRef.current || 1) < 1 ? 1.15 : zoomRef.current));
             fgRef.current!.zoom(targetK, 600);
         };

--- a/src/components/GenresForceGraph.tsx
+++ b/src/components/GenresForceGraph.tsx
@@ -25,11 +25,13 @@ interface GenresForceGraphProps {
     colorMap?: Map<string, string>;
     // Selected genre id to highlight and focus
     selectedGenreId?: string;
+    width?: number;
+    height?: number;
 }
 
 // Styling shared via graphStyle utils
 
-const GenresForceGraph = forwardRef<GraphHandle, GenresForceGraphProps>(({ graphData, onNodeClick, loading, show, dag, clusterModes, colorMap: externalColorMap, selectedGenreId }, ref) => {
+const GenresForceGraph = forwardRef<GraphHandle, GenresForceGraphProps>(({ graphData, onNodeClick, loading, show, dag, clusterModes, colorMap: externalColorMap, selectedGenreId, width, height }, ref) => {
     const fgRef = useRef<ForceGraphMethods<Genre, NodeLink> | undefined>(undefined);
     const zoomRef = useRef<number>(1);
     const [hoveredId, setHoveredId] = useState<string | undefined>(undefined);
@@ -294,6 +296,8 @@ const GenresForceGraph = forwardRef<GraphHandle, GenresForceGraphProps>(({ graph
              d3VelocityDecay={.75}    // How springy tugs feel; smaller → more inertia
             cooldownTime={20000} // How long to run the simulation before stopping
             autoPauseRedraw={false}
+            width={width}
+            height={height}
             graphData={preparedData}
             dagMode={dag ? 'radialin' : undefined}
             dagLevelDistance={200}

--- a/src/components/Gradient.tsx
+++ b/src/components/Gradient.tsx
@@ -11,19 +11,19 @@ export function Gradient() {
                     {/* <div className="fixed top-1/2 left-1/2 w-screen h-auto aspect-square -translate-x-1/2 -translate-y-1/2 pointer-events-none rounded-full bg-[radial-gradient(circle_at_center,rgba(255,255,255)_60%,rgba(255,255,255,.2)_100%)] " /> */}
                     {/* gradient */}
                     <div className="-z-2 fixed top-1/2 left-1/2 w-screen aspect-square h-full -translate-x-1/2 -translate-y-1/2 pointer-events-none backdrop-blur-xs [mask-image:radial-gradient(circle_at_center,rgba(0,0,0,0)_60%,rgba(0,0,0,0.2)_70%,rgba(0,0,0,.8)_97%)]"/>
-                    <div className="fixed top-1/2 left-1/2 w-screen aspect-square h-full -translate-x-1/2 -translate-y-1/2 pointer-events-none z-10
+                    <div className="fixed top-1/2 left-1/2 w-screen aspect-square h-full -translate-x-1/2 -translate-y-1/2 pointer-events-none z-0
                     bg-[radial-gradient(circle_at_center,rgba(255,255,255,0)_60%,rgba(255,255,255,0.2)_70%,rgba(255,255,255,.8)_97%)]" />
                     {/* noise */}
-                    <div className="fixed inset-0 pointer-events-none noise" />
+                    <div className="fixed inset-0 pointer-events-none z-[9] noise" />
                     {/* Blur */}
                 </>
             ) 
             :
             <>
-                <div className="-z-2 fixed top-1/2 left-1/2 w-screen aspect-square h-full -translate-x-1/2 -translate-y-1/2 pointer-events-none backdrop-blur-xs [mask-image:radial-gradient(circle_at_center,rgba(255,255,255,0)_60%,rgba(255,255,255,0.2)_70%,rgba(255,255,255,.8)_97%)]"/>
-                <div className="fixed top-1/2 left-1/2 w-screen aspect-square h-full -translate-x-1/2 -translate-y-1/2 pointer-events-none z-10
+                <div className="-z-2 fixed top-1/2 left-1/2 w-screen aspect-square h-full -translate-x-1/2 -translate-y-1/2 pointer-events-none backdrop-blur-lg [mask-image:radial-gradient(circle_at_center,rgba(255,255,255,0)_60%,rgba(255,255,255,0.2)_70%,rgba(255,255,255,.8)_97%)]"/>
+                <div className="fixed top-1/2 left-1/2 w-screen aspect-square h-full -translate-x-1/2 -translate-y-1/2 pointer-events-none z-5
                 bg-[radial-gradient(circle_at_center,rgba(0,0,0,0)_60%,rgba(0,0,0,0.2)_70%,rgba(0,0,0,.8)_97%)]" />
-                <div className="fixed inset-0 pointer-events-none noise-dark" /> 
+                <div className="fixed inset-0 pointer-events-none z-[9] noise-dark" /> 
             </> }
         </>
     );

--- a/src/components/Gradient.tsx
+++ b/src/components/Gradient.tsx
@@ -11,19 +11,19 @@ export function Gradient() {
                     {/* <div className="fixed top-1/2 left-1/2 w-screen h-auto aspect-square -translate-x-1/2 -translate-y-1/2 pointer-events-none rounded-full bg-[radial-gradient(circle_at_center,rgba(255,255,255)_60%,rgba(255,255,255,.2)_100%)] " /> */}
                     {/* gradient */}
                     <div className="-z-2 fixed top-1/2 left-1/2 w-screen aspect-square h-full -translate-x-1/2 -translate-y-1/2 pointer-events-none backdrop-blur-xs [mask-image:radial-gradient(circle_at_center,rgba(0,0,0,0)_60%,rgba(0,0,0,0.2)_70%,rgba(0,0,0,.8)_97%)]"/>
-                    <div className="fixed top-1/2 left-1/2 w-screen aspect-square h-full -translate-x-1/2 -translate-y-1/2 pointer-events-none z-0
+                    <div className="fixed top-1/2 left-1/2 w-screen aspect-square h-full -translate-x-1/2 -translate-y-1/2 pointer-events-none z-10
                     bg-[radial-gradient(circle_at_center,rgba(255,255,255,0)_60%,rgba(255,255,255,0.2)_70%,rgba(255,255,255,.8)_97%)]" />
-                    {/* noise */}
-                    <div className="fixed inset-0 pointer-events-none z-[9] noise" />
+                    {/* noise (behind graph) */}
+                    <div className="fixed inset-0 pointer-events-none z-[-1] noise" />
                     {/* Blur */}
                 </>
             ) 
             :
             <>
-                <div className="-z-2 fixed top-1/2 left-1/2 w-screen aspect-square h-full -translate-x-1/2 -translate-y-1/2 pointer-events-none backdrop-blur-lg [mask-image:radial-gradient(circle_at_center,rgba(255,255,255,0)_60%,rgba(255,255,255,0.2)_70%,rgba(255,255,255,.8)_97%)]"/>
-                <div className="fixed top-1/2 left-1/2 w-screen aspect-square h-full -translate-x-1/2 -translate-y-1/2 pointer-events-none z-5
+                <div className="-z-2 fixed top-1/2 left-1/2 w-screen aspect-square h-full -translate-x-1/2 -translate-y-1/2 pointer-events-none backdrop-blur-xs [mask-image:radial-gradient(circle_at_center,rgba(255,255,255,0)_60%,rgba(255,255,255,0.2)_70%,rgba(255,255,255,.8)_97%)]"/>
+                <div className="fixed top-1/2 left-1/2 w-screen aspect-square h-full -translate-x-1/2 -translate-y-1/2 pointer-events-none z-10
                 bg-[radial-gradient(circle_at_center,rgba(0,0,0,0)_60%,rgba(0,0,0,0.2)_70%,rgba(0,0,0,.8)_97%)]" />
-                <div className="fixed inset-0 pointer-events-none z-[9] noise-dark" /> 
+                <div className="fixed inset-0 pointer-events-none z-[-1] noise-dark" /> 
             </> }
         </>
     );

--- a/src/components/MobileAppBar.tsx
+++ b/src/components/MobileAppBar.tsx
@@ -17,6 +17,7 @@ type MobileAppBarProps = {
   graph: GraphType
   onGraphChange: (g: GraphType) => void
   onOpenSearch: () => void
+  resetAppState: () => void;
 }
 
 /**
@@ -24,7 +25,7 @@ type MobileAppBarProps = {
  * Provides quick access to Search, Collection, Genres, Artists, and a More menu.
  * Styled to match the existing glassy/rounded aesthetic.
  */
-export function MobileAppBar({ graph, onGraphChange, onOpenSearch }: MobileAppBarProps) {
+export function MobileAppBar({ graph, onGraphChange, onOpenSearch,resetAppState }: MobileAppBarProps) {
   return (
     <div className="pointer-events-none fixed flex justify-center gap-3 inset-x-0 bottom-3 z-50 md:hidden"
     style={{ paddingBottom: "env(safe-area-inset-bottom)" }}>
@@ -54,13 +55,13 @@ export function MobileAppBar({ graph, onGraphChange, onOpenSearch }: MobileAppBa
           /> */}
           <ToolbarButton
             label="Collection"
-            onClick={() => toast("Collections are coming soon ✨")}
+            onClick={() => window.dispatchEvent(new Event('auth:open'))}
             icon={<BookOpen className="size-6" />}
           />
           <ToolbarButton
             label="Explore"
             active={graph === "genres"}
-            onClick={() => onGraphChange("genres")}
+            onClick={resetAppState}
             icon={<Telescope className="size-6" />}
           />
           {/* <ToolbarButton

--- a/src/components/ZoomButtons.tsx
+++ b/src/components/ZoomButtons.tsx
@@ -12,7 +12,7 @@ const ZoomButtons: React.FC<ZoomButtonsProps> = ({ onZoomIn, onZoomOut }) => {
       <Button
         variant='outline'
         size='icon'
-        className='rounded-none border-0 shadow-none focus:outline-none focus-visible:outline-none focus-visible:ring-0 focus-visible:shadow-none focus-visible:border-transparent first:rounded-t-full'
+        className='rounded-none border-0 border-b shadow-none focus:outline-none focus-visible:outline-none focus-visible:ring-0 focus-visible:shadow-none focus-visible:border-transparent first:rounded-t-full'
         onClick={onZoomIn}
         aria-label='Zoom in'
         title='Zoom in'

--- a/src/lib/graphStyle.ts
+++ b/src/lib/graphStyle.ts
@@ -3,6 +3,8 @@
 export const LABEL_FONT_SIZE = 12;
 export const DEFAULT_LABEL_FADE_START = .1;
 export const DEFAULT_LABEL_FADE_END = .3;
+// Default upward screen-space offset (in px) to lift a focused node on mobile
+export const DEFAULT_MOBILE_CENTER_OFFSET_PX = 140;
 
 export const smoothstep = (t: number) => t * t * (3 - 2 * t);
 
@@ -15,6 +17,22 @@ export function labelAlphaForZoom(
   const denom = Math.max(1e-6, end - start);
   const t = Math.max(0, Math.min(1, (k - start) / denom));
   return smoothstep(t);
+}
+
+// Convert a screen-space pixel offset to world-space, given current zoom k
+export function worldOffsetForScreenOffset(px: number, k: number): number {
+  return px / Math.max(k || 1, 1e-6);
+}
+
+// Convenience: apply an upward drawer offset for mobile when centering
+export function applyMobileDrawerYOffset(
+  y: number,
+  k: number,
+  isMobile: boolean,
+  offsetPx: number = DEFAULT_MOBILE_CENTER_OFFSET_PX
+): number {
+  if (!isMobile || !offsetPx) return y;
+  return y + worldOffsetForScreenOffset(offsetPx, k);
 }
 
 export function estimateLabelWidth(name: string, fontPx = LABEL_FONT_SIZE): number {


### PR DESCRIPTION
**Changes**
- Centralized the mobile centering offset with DEFAULT_MOBILE_CENTER_OFFSET_PX in graphStyles.tsx because the bottom drawer was blocking the selected node
- Added resetAppState to mobile 'Explore' button
- Added AuthOverlay to mobile 'Collection' button
- Added viewport state that tracks window size. added to new width and height props on graphs so they resize properly