### PR TITLE
Split button style updates and more button hotfix

### DIFF
--- a/src/components/GenreInfo.tsx
+++ b/src/components/GenreInfo.tsx
@@ -503,7 +503,7 @@ export function GenreInfo({
                           <Button
                             variant={`${isDesktop ? 'secondary' : 'secondary'}`}
                             size={`${isDesktop ? 'lg' : 'xl'}`}
-                            className={`"shrink-0  ${isDesktop ? '' : 'flex-1'}}`}
+                            className={`"shrink-0 ${isDesktop ? '' : 'flex-1 '}}`}
                             title="More options"
                           >
                             <Ellipsis className="h-4 w-4" />

--- a/src/components/ui/button-group.tsx
+++ b/src/components/ui/button-group.tsx
@@ -10,7 +10,7 @@ const buttonGroupVariants = cva(
     variants: {
       orientation: {
         horizontal:
-          "[&>*:not(:first-child)]:rounded-l-none [&>*:not(:first-child)]:border-l-0 [&>*:not(:last-child)]:rounded-r-none",
+          "[&>*:not(:first-child)]:rounded-l-md [&>*:not(:first-child)]:border-l-0 [&>*:not(:last-child)]:rounded-r-sm",
         vertical:
           "flex-col [&>*:not(:first-child)]:rounded-t-none [&>*:not(:first-child)]:border-t-0 [&>*:not(:last-child)]:rounded-b-none",
       },

--- a/src/components/ui/split-button.tsx
+++ b/src/components/ui/split-button.tsx
@@ -33,7 +33,7 @@ function SplitButton({
 
   return (
     <SplitButtonContext.Provider value={contextValue}>
-      <ButtonGroup className={cn("self-start", className)} {...props}>
+      <ButtonGroup className={cn("self-start space-x-0.5 rounded-full overflow-clip", className)} {...props}>
         {children}
       </ButtonGroup>
     </SplitButtonContext.Provider>
@@ -52,7 +52,7 @@ const SplitButtonAction = React.forwardRef<HTMLButtonElement, React.ComponentPro
         disabled={disabled}
         className={cn(
           buttonVariants({ variant, size }),
-          "!pr-1.5 !rounded-r-md border-r-2 border-black",
+          "!pr-3.5 !rounded-[4px]",
           className
         )}
         {...props}
@@ -91,7 +91,7 @@ const SplitButtonTrigger = React.forwardRef<HTMLButtonElement, SplitButtonTrigge
         aria-label={ariaLabel}
         className={cn(
           buttonVariants({ variant, size }),
-          "h-auto !pl-1 !pr-2 !rounded-l-md",
+          "h-auto !pl-2 !pr-3 !rounded-[4px]",
           className
         )}
         {...props}

--- a/src/components/ui/split-button.tsx
+++ b/src/components/ui/split-button.tsx
@@ -52,7 +52,7 @@ const SplitButtonAction = React.forwardRef<HTMLButtonElement, React.ComponentPro
         disabled={disabled}
         className={cn(
           buttonVariants({ variant, size }),
-          "!pr-1.5",
+          "!pr-1.5 !rounded-r-md border-r-2 border-black",
           className
         )}
         {...props}
@@ -91,7 +91,7 @@ const SplitButtonTrigger = React.forwardRef<HTMLButtonElement, SplitButtonTrigge
         aria-label={ariaLabel}
         className={cn(
           buttonVariants({ variant, size }),
-          "h-auto !pl-1 !pr-2",
+          "h-auto !pl-1 !pr-2 !rounded-l-md",
           className
         )}
         {...props}


### PR DESCRIPTION
## Changes
- added inner radius to split button
- fixed issue where more button on genre info drawer was hugging content instead of sharing space
<img width="587" height="144" alt="Screenshot 2026-04-02 at 10 24 23 PM" src="https://github.com/user-attachments/assets/a9b411e7-dfdd-4d8b-a92c-a9ac81f202a8" />
<img width="444" height="479" alt="Screenshot 2026-04-02 at 10 25 56 PM" src="https://github.com/user-attachments/assets/2a369aec-02d8-40ce-892a-291401eb29dd" />
