### PR TITLE
Feat/Cluster by genre

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -172,8 +172,38 @@ function App() {
   const [genreTopArtistsCache, setGenreTopArtistsCache] = useState<Map<string, Artist[]>>(new Map());
   const [canCreateSimilarArtistGraph, setCanCreateSimilarArtistGraph] = useState<boolean>(false);
   const [genreClusterMode, setGenreClusterMode] = useState<GenreClusterMode[]>(DEFAULT_CLUSTER_MODE);
-  const [artistClusterMethod, setArtistClusterMethod] = useState<ArtistClusterMode>(() => {
-    const stored = localStorage.getItem('artistClusterMethod');
+  const [collectionArtistClusterMethod, setCollectionArtistClusterMethod] = useState<ArtistClusterMode>(() => {
+    // Try new key first, fall back to old key for backward compatibility
+    let stored = localStorage.getItem('collectionArtistClusterMethod');
+    if (!stored) {
+      stored = localStorage.getItem('artistClusterMethod');
+    }
+    if (stored === 'louvain') {
+      return 'similarArtists';
+    }
+    if (stored === 'listeners') {
+      return 'popularity';
+    }
+    if (stored === 'similarArtists' || stored === 'byTags' || stored === 'popularity' || stored === 'genre') {
+      return stored;
+    }
+    return DEFAULT_ARTIST_CLUSTER_MODE;
+  });
+  const [exploreArtistClusterMethod, setExploreArtistClusterMethod] = useState<ArtistClusterMode>(() => {
+    const stored = localStorage.getItem('exploreArtistClusterMethod');
+    if (stored === 'louvain') {
+      return 'similarArtists';
+    }
+    if (stored === 'listeners') {
+      return 'popularity';
+    }
+    if (stored === 'similarArtists' || stored === 'byTags' || stored === 'popularity' || stored === 'genre') {
+      return stored;
+    }
+    return DEFAULT_ARTIST_CLUSTER_MODE;
+  });
+  const [similarArtistClusterMethod, setSimilarArtistClusterMethod] = useState<ArtistClusterMode>(() => {
+    const stored = localStorage.getItem('similarArtistClusterMethod');
     if (stored === 'louvain') {
       return 'similarArtists';
     }
@@ -864,6 +894,16 @@ function App() {
 
     setClusteringInProgress(true);
 
+    // Select the appropriate clustering method based on the current view
+    let artistClusterMethod: ArtistClusterMode;
+    if (graph === 'similarArtists') {
+      artistClusterMethod = similarArtistClusterMethod;
+    } else if (graph === 'artists' && collectionMode) {
+      artistClusterMethod = collectionArtistClusterMethod;
+    } else {
+      artistClusterMethod = exploreArtistClusterMethod;
+    }
+
     // Debounce clustering computation and run it async
     clusteringTimeoutRef.current = setTimeout(() => {
       // Use requestIdleCallback if available, otherwise setTimeout with delay
@@ -904,7 +944,7 @@ function App() {
         clearTimeout(clusteringTimeoutRef.current);
       }
     };
-  }, [currentArtists, currentArtistLinks, graph, artistClusterMethod, resolvedTheme, artistGenreAssignments]);
+  }, [currentArtists, currentArtistLinks, graph, collectionMode, collectionArtistClusterMethod, exploreArtistClusterMethod, similarArtistClusterMethod, resolvedTheme, artistGenreAssignments]);
 
   // Use generated links from clustering (artists colored by parent genre)
   useEffect(() => {
@@ -961,6 +1001,14 @@ function App() {
 
   // Cluster hull overlays for genre, byTags, and popularity modes
   const artistClusterOverlays = useMemo((): ClusterOverlay[] | undefined => {
+    let artistClusterMethod: ArtistClusterMode;
+    if (graph === 'similarArtists') {
+      artistClusterMethod = similarArtistClusterMethod;
+    } else if (graph === 'artists' && collectionMode) {
+      artistClusterMethod = collectionArtistClusterMethod;
+    } else {
+      artistClusterMethod = exploreArtistClusterMethod;
+    }
     if (!artistClusters || !['genre', 'byTags', 'popularity'].includes(artistClusterMethod) || !showClusterOverlay) return undefined;
     const overlays: ClusterOverlay[] = [];
     for (const cluster of artistClusters.clusters.values()) {
@@ -973,7 +1021,7 @@ function App() {
       });
     }
     return overlays.length > 0 ? overlays : undefined;
-  }, [artistClusters, artistClusterMethod, showClusterOverlay]);
+  }, [artistClusters, graph, collectionMode, collectionArtistClusterMethod, exploreArtistClusterMethod, similarArtistClusterMethod, showClusterOverlay]);
 
   // Compute radial layout from cluster tier data for popularity stratification
   const artistRadialLayout = useMemo(() => {
@@ -3011,14 +3059,22 @@ function App() {
               {(graph === 'genres' || graph === 'artists' || graph === 'similarArtists') && (
                 <ClusteringPanel
                   graphType={graph === 'genres' ? 'genres' : 'artists'}
-                  clusterMode={graph === 'genres' ? genreClusterMode[0] : artistClusterMethod}
+                  clusterMode={graph === 'genres' ? genreClusterMode[0] : (graph === 'similarArtists' ? similarArtistClusterMethod : (collectionMode ? collectionArtistClusterMethod : exploreArtistClusterMethod))}
                   setClusterMode={(mode) => {
                     if (graph === 'genres') {
                       onGenreClusterModeChange(mode as GenreClusterMode[]);
                     } else {
                       const newMethod = (Array.isArray(mode) ? mode[0] : mode) as ArtistClusterMode;
-                      setArtistClusterMethod(newMethod);
-                      localStorage.setItem('artistClusterMethod', newMethod);
+                      if (graph === 'similarArtists') {
+                        setSimilarArtistClusterMethod(newMethod);
+                        localStorage.setItem('similarArtistClusterMethod', newMethod);
+                      } else if (collectionMode) {
+                        setCollectionArtistClusterMethod(newMethod);
+                        localStorage.setItem('collectionArtistClusterMethod', newMethod);
+                      } else {
+                        setExploreArtistClusterMethod(newMethod);
+                        localStorage.setItem('exploreArtistClusterMethod', newMethod);
+                      }
                     }
                   }}
                   dagMode={dagMode}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -180,7 +180,7 @@ function App() {
     if (stored === 'listeners') {
       return 'popularity';
     }
-    if (stored === 'similarArtists' || stored === 'hybrid' || stored === 'popularity' || stored === 'genre') {
+    if (stored === 'similarArtists' || stored === 'byTags' || stored === 'popularity' || stored === 'genre') {
       return stored;
     }
     return DEFAULT_ARTIST_CLUSTER_MODE;
@@ -959,9 +959,9 @@ function App() {
     }
   }, [artistClusters, graph, currentArtistLinks, filterArtistLinksByClusters, currentArtists]);
 
-  // Cluster hull overlays for "By Genre" mode
+  // Cluster hull overlays for genre, byTags, and popularity modes
   const artistClusterOverlays = useMemo((): ClusterOverlay[] | undefined => {
-    if (!artistClusters || artistClusterMethod !== 'genre' || !showClusterOverlay) return undefined;
+    if (!artistClusters || !['genre', 'byTags', 'popularity'].includes(artistClusterMethod) || !showClusterOverlay) return undefined;
     const overlays: ClusterOverlay[] = [];
     for (const cluster of artistClusters.clusters.values()) {
       if (cluster.artistIds.length === 0) continue;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -189,6 +189,10 @@ function App() {
     const stored = localStorage.getItem('artistColorMode');
     return (stored === 'cluster' ? 'cluster' : 'genre') as 'genre' | 'cluster';
   });
+  const [showClusterOverlay, setShowClusterOverlay] = useState<boolean>(() => {
+    const stored = localStorage.getItem('showClusterOverlay');
+    return stored === null ? true : stored === 'true';
+  });
   const [dagMode, setDagMode] = useState<boolean>(() => {
     const storedDagMode = localStorage.getItem('dagMode');
     return storedDagMode ? JSON.parse(storedDagMode) : false;
@@ -957,7 +961,7 @@ function App() {
 
   // Cluster hull overlays for "By Genre" mode
   const artistClusterOverlays = useMemo((): ClusterOverlay[] | undefined => {
-    if (!artistClusters || artistClusterMethod !== 'genre') return undefined;
+    if (!artistClusters || artistClusterMethod !== 'genre' || !showClusterOverlay) return undefined;
     const overlays: ClusterOverlay[] = [];
     for (const cluster of artistClusters.clusters.values()) {
       if (cluster.artistIds.length === 0) continue;
@@ -969,7 +973,7 @@ function App() {
       });
     }
     return overlays.length > 0 ? overlays : undefined;
-  }, [artistClusters, artistClusterMethod]);
+  }, [artistClusters, artistClusterMethod, showClusterOverlay]);
 
   // Compute radial layout from cluster tier data for popularity stratification
   const artistRadialLayout = useMemo(() => {
@@ -3028,6 +3032,11 @@ function App() {
                   artistClusters={(graph === 'artists' || graph === 'similarArtists') ? artistClusters : undefined}
                   clusteringInProgress={(graph === 'artists' || graph === 'similarArtists') ? clusteringInProgress : undefined}
                   collectionMode={collectionMode}
+                  showClusterOverlay={showClusterOverlay}
+                  setShowClusterOverlay={(v) => {
+                    setShowClusterOverlay(v);
+                    localStorage.setItem('showClusterOverlay', String(v));
+                  }}
                 />
               )}
               <DisplayPanel

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import useArtists from "@/hooks/useArtists";
 import useGenres from "@/hooks/useGenres";
 import useGenreTopArtists from "@/hooks/useGenreTopArtists";
 import ArtistsForceGraph, { type GraphHandle } from "@/components/ArtistsForceGraph";
+import type { ClusterOverlay } from "@/components/Graph";
 import GenresForceGraph from "@/components/GenresForceGraph";
 import {
   Artist, ArtistClusterMode, ArtistNodeLimitType, BadDataReport, ContextAction, FindOption,
@@ -953,6 +954,22 @@ function App() {
       setFilteredArtistLinks(currentArtistLinks);
     }
   }, [artistClusters, graph, currentArtistLinks, filterArtistLinksByClusters, currentArtists]);
+
+  // Cluster hull overlays for "By Genre" mode
+  const artistClusterOverlays = useMemo((): ClusterOverlay[] | undefined => {
+    if (!artistClusters || artistClusterMethod !== 'genre') return undefined;
+    const overlays: ClusterOverlay[] = [];
+    for (const cluster of artistClusters.clusters.values()) {
+      if (cluster.artistIds.length === 0) continue;
+      overlays.push({
+        id: cluster.id,
+        name: cluster.name,
+        color: cluster.color,
+        nodeIds: new Set(cluster.artistIds),
+      });
+    }
+    return overlays.length > 0 ? overlays : undefined;
+  }, [artistClusters, artistClusterMethod]);
 
   // Compute radial layout from cluster tier data for popularity stratification
   const artistRadialLayout = useMemo(() => {
@@ -2882,6 +2899,7 @@ function App() {
                   disableDimming={isUserDraggingArtistCanvas || isArtistDrawerAtMinSnap}
                   radialLayout={artistRadialLayout}
                   priorityLabelIds={centralArtistLabelIds}
+                  clusterOverlays={artistClusterOverlays}
                 />
 
           {/* Genre hover preview */}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1009,7 +1009,7 @@ function App() {
     } else {
       artistClusterMethod = exploreArtistClusterMethod;
     }
-    if (!artistClusters || !['genre', 'byTags', 'popularity'].includes(artistClusterMethod) || !showClusterOverlay) return undefined;
+    if (!artistClusters || !['genre', 'popularity'].includes(artistClusterMethod) || !showClusterOverlay) return undefined;
     const overlays: ClusterOverlay[] = [];
     for (const cluster of artistClusters.clusters.values()) {
       if (cluster.artistIds.length === 0) continue;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -179,7 +179,7 @@ function App() {
     if (stored === 'listeners') {
       return 'popularity';
     }
-    if (stored === 'similarArtists' || stored === 'hybrid' || stored === 'popularity') {
+    if (stored === 'similarArtists' || stored === 'hybrid' || stored === 'popularity' || stored === 'genre') {
       return stored;
     }
     return DEFAULT_ARTIST_CLUSTER_MODE;
@@ -769,6 +769,77 @@ function App() {
     });
   }, [graph]);
 
+  // Pre-compute per-artist root genre assignment for "By Genre" clustering (collection mode)
+  const artistGenreAssignments = useMemo((): {
+    assignments: Map<string, string>;
+    colors: Map<string, string>;
+    names: Map<string, string>;
+  } => {
+    const assignments = new Map<string, string>();
+    const colors = new Map<string, string>();
+    const names = new Map<string, string>();
+
+    if (!currentArtists.length || !genres.length) return { assignments, colors, names };
+
+    const isDark = resolvedTheme === 'dark';
+    const genreById = new Map(genres.map(g => [g.id, g]));
+    const genreByName = new Map(genres.map(g => [g.name, g]));
+    const rootIdLookup = new Set(genreRoots);
+    const genreNameById = new Map(genres.map(g => [g.id, g.name]));
+
+    const globalRootArtistCount = new Map<string, number>();
+    genres.forEach(genre => {
+      if (genre.rootGenres?.length) {
+        genre.rootGenres.forEach(rootId => {
+          globalRootArtistCount.set(rootId, (globalRootArtistCount.get(rootId) ?? 0) + genre.artistCount);
+        });
+      }
+      if (rootIdLookup.has(genre.id)) {
+        globalRootArtistCount.set(genre.id, (globalRootArtistCount.get(genre.id) ?? 0) + genre.artistCount);
+      }
+    });
+    const rootColorMap = assignRootGenreColors(genreRoots, isDark, globalRootArtistCount);
+
+    currentArtists.forEach(artist => {
+      let rootGenreId: string | null = null;
+
+      if (artist.tags?.length) {
+        const genreTags = artist.tags
+          .filter(t => genreByName.has(t.name))
+          .sort((a, b) => b.count - a.count);
+        if (genreTags.length > 0) {
+          const tagGenre = genreByName.get(genreTags[0].name);
+          if (tagGenre?.rootGenres?.[0]) rootGenreId = tagGenre.rootGenres[0];
+        }
+      }
+
+      if (!rootGenreId && artist.genres?.length) {
+        const firstGenre = genreById.get(artist.genres[0]);
+        if (firstGenre?.rootGenres?.[0]) {
+          rootGenreId = firstGenre.rootGenres[0];
+        } else if (firstGenre && rootIdLookup.has(firstGenre.id)) {
+          rootGenreId = firstGenre.id;
+        }
+      }
+
+      const finalRootId = rootGenreId ?? 'unknown';
+      assignments.set(artist.id, finalRootId);
+
+      if (finalRootId !== 'unknown' && !colors.has(finalRootId)) {
+        const color = rootColorMap.get(finalRootId);
+        if (color) {
+          colors.set(finalRootId, color);
+          names.set(finalRootId, genreNameById.get(finalRootId) ?? finalRootId);
+        }
+      }
+    });
+
+    colors.set('unknown', isDark ? DEFAULT_DARK_NODE_COLOR : DEFAULT_LIGHT_NODE_COLOR);
+    names.set('unknown', 'Unknown Genre');
+
+    return { assignments, colors, names };
+  }, [currentArtists, genres, genreRoots, resolvedTheme]);
+
   // Compute artist clusters using selected clustering method
   // Use async computation for large graphs to avoid blocking UI
   const [artistClusters, setArtistClusters] = useState<ClusterResult | null>(null);
@@ -806,6 +877,11 @@ function App() {
           const result = engine.cluster({
             method: artistClusterMethod,
             resolution: 1.0,
+            ...(artistClusterMethod === 'genre' && {
+              genreAssignments: artistGenreAssignments.assignments,
+              genreColors: artistGenreAssignments.colors,
+              genreNames: artistGenreAssignments.names,
+            }),
           });
           setArtistClusters(result);
         } catch (error) {
@@ -823,7 +899,7 @@ function App() {
         clearTimeout(clusteringTimeoutRef.current);
       }
     };
-  }, [currentArtists, currentArtistLinks, graph, artistClusterMethod, resolvedTheme]);
+  }, [currentArtists, currentArtistLinks, graph, artistClusterMethod, resolvedTheme, artistGenreAssignments]);
 
   // Use generated links from clustering (artists colored by parent genre)
   useEffect(() => {
@@ -2933,6 +3009,7 @@ function App() {
                   genreColorLegend={genreColorLegend}
                   artistClusters={(graph === 'artists' || graph === 'similarArtists') ? artistClusters : undefined}
                   clusteringInProgress={(graph === 'artists' || graph === 'similarArtists') ? clusteringInProgress : undefined}
+                  collectionMode={collectionMode}
                 />
               )}
               <DisplayPanel

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -809,12 +809,14 @@ function App() {
     assignments: Map<string, string>;
     colors: Map<string, string>;
     names: Map<string, string>;
+    primaryGenreTags: Map<string, string>;
   } => {
     const assignments = new Map<string, string>();
     const colors = new Map<string, string>();
     const names = new Map<string, string>();
+    const primaryGenreTags = new Map<string, string>();
 
-    if (!currentArtists.length || !genres.length) return { assignments, colors, names };
+    if (!currentArtists.length || !genres.length) return { assignments, colors, names, primaryGenreTags };
 
     const isDark = resolvedTheme === 'dark';
     const genreById = new Map(genres.map(g => [g.id, g]));
@@ -843,6 +845,7 @@ function App() {
           .filter(t => genreByName.has(t.name))
           .sort((a, b) => b.count - a.count);
         if (genreTags.length > 0) {
+          primaryGenreTags.set(artist.id, genreTags[0].name);
           const tagGenre = genreByName.get(genreTags[0].name);
           if (tagGenre?.rootGenres?.[0]) rootGenreId = tagGenre.rootGenres[0];
         }
@@ -872,7 +875,7 @@ function App() {
     colors.set('unknown', isDark ? DEFAULT_DARK_NODE_COLOR : DEFAULT_LIGHT_NODE_COLOR);
     names.set('unknown', 'Unknown Genre');
 
-    return { assignments, colors, names };
+    return { assignments, colors, names, primaryGenreTags };
   }, [currentArtists, genres, genreRoots, resolvedTheme]);
 
   // Compute artist clusters using selected clustering method
@@ -926,6 +929,7 @@ function App() {
               genreAssignments: artistGenreAssignments.assignments,
               genreColors: artistGenreAssignments.colors,
               genreNames: artistGenreAssignments.names,
+              artistPrimaryGenreTags: artistGenreAssignments.primaryGenreTags,
             }),
           });
           setArtistClusters(result);

--- a/src/components/ArtistsForceGraph.tsx
+++ b/src/components/ArtistsForceGraph.tsx
@@ -2,6 +2,7 @@ import { forwardRef, memo, useMemo } from "react";
 import Graph, {
   type GraphHandle,
   type SharedGraphNode,
+  type ClusterOverlay,
 } from "./Graph";
 import { calculateNodeRadius, DEFAULT_MIN_RADIUS, DEFAULT_MAX_RADIUS } from "./Graph/graphStyle";
 import { Artist, NodeLink } from "@/types";
@@ -37,6 +38,7 @@ interface ArtistsForceGraphProps {
     nodeToRadius: Map<string, number>;
     strength?: number;
   };
+  clusterOverlays?: ClusterOverlay[];
 }
 
 
@@ -67,6 +69,7 @@ const ArtistsForceGraph = forwardRef<GraphHandle, ArtistsForceGraphProps>(
       disableDimming,
       priorityLabelIds,
       radialLayout,
+      clusterOverlays,
     },
     ref,
   ) => {
@@ -140,6 +143,7 @@ const ArtistsForceGraph = forwardRef<GraphHandle, ArtistsForceGraphProps>(
         disableDimming={disableDimming}
         priorityLabelIds={priorityLabelIds}
         radialLayout={radialLayout}
+        clusterOverlays={clusterOverlays}
       />
     );
   },

--- a/src/components/ClusteringPanel.tsx
+++ b/src/components/ClusteringPanel.tsx
@@ -47,11 +47,18 @@ export default function ClusteringPanel({
     const artistOptions = [
         { id: "similarArtists", label: "Similar Artists", description: "Uses the existing artist network structure to find communities. Artists connected by similar artist links form clusters." },
         { id: "popularity", label: "Popularity", description: "Arranges artists in concentric rings by listener count. Popular artists at center, underground at outer ring." },
-        ...(collectionMode ? [{
-            id: "genre",
-            label: "By Genre",
-            description: "Groups your liked artists into clusters by their primary genre — Rock, Electronic, Hip-Hop, and so on. Same-genre artists are physically pulled together.",
-        }] : []),
+        ...(collectionMode ? [
+            {
+                id: "genre",
+                label: "By Genre",
+                description: "Groups your liked artists into clusters by their primary genre — Rock, Electronic, Hip-Hop, and so on. Same-genre artists are physically pulled together.",
+            },
+            {
+                id: "byTags",
+                label: "By Tags",
+                description: "Combines tag-based similarity with your artist network structure to find communities. Blends musical similarity with direct connections.",
+            },
+        ] : []),
     ];
 
     const options = graphType === 'genres' ? genreOptions : artistOptions;
@@ -125,13 +132,13 @@ export default function ClusteringPanel({
                         </motion.div>
                     ))}
                 </RadioGroup>
-                {graphType === 'artists' && clusterMode === 'genre' && setShowClusterOverlay && (
+                {graphType === 'artists' && ['genre', 'byTags', 'popularity'].includes(clusterMode) && setShowClusterOverlay && (
                     <div className={`${feildsetStyles} flex items-center justify-between w-full p-3`}>
                         <div className="flex flex-col">
                             <span className="text-md font-semibold leading-none text-gray-900 dark:text-gray-100">Show cluster overlay</span>
-                            <span className="text-sm text-muted-foreground mt-1">Draw genre region hulls on the graph.</span>
+                            <span className="text-sm text-muted-foreground mt-1">Draw cluster region hulls on the graph.</span>
                         </div>
-                        <Switch checked={showClusterOverlay ?? true} onCheckedChange={setShowClusterOverlay} />
+                        <Switch checked={showClusterOverlay ?? false} onCheckedChange={setShowClusterOverlay} />
                     </div>
                 )}
                 {graphType === 'artists' && artistColorMode !== undefined && setArtistColorMode && (

--- a/src/components/ClusteringPanel.tsx
+++ b/src/components/ClusteringPanel.tsx
@@ -63,7 +63,7 @@ export default function ClusteringPanel({
 
     const options = graphType === 'genres' ? genreOptions : artistOptions;
 
-    const feildsetStyles = "rounded-2xl bg-accent dark:bg-accent/50 border border-muted"
+    const feildsetStyles = "rounded-2xl bg-accent dark:bg-accent/50 border border-accent"
 
     return (
         <ResponsivePanel
@@ -132,7 +132,7 @@ export default function ClusteringPanel({
                         </motion.div>
                     ))}
                 </RadioGroup>
-                {graphType === 'artists' && ['genre', 'popularity'].includes(clusterMode) && setShowClusterOverlay && (
+                {graphType === 'artists' && ['genre', 'byTags', 'popularity'].includes(clusterMode) && setShowClusterOverlay && (
                     <div className={`${feildsetStyles} flex items-center justify-between w-full p-3`}>
                         <div className="flex flex-col">
                             <span className="text-md font-semibold leading-none text-gray-900 dark:text-gray-100">Show cluster overlay</span>

--- a/src/components/ClusteringPanel.tsx
+++ b/src/components/ClusteringPanel.tsx
@@ -132,7 +132,7 @@ export default function ClusteringPanel({
                         </motion.div>
                     ))}
                 </RadioGroup>
-                {graphType === 'artists' && ['genre', 'byTags', 'popularity'].includes(clusterMode) && setShowClusterOverlay && (
+                {graphType === 'artists' && ['genre', 'popularity'].includes(clusterMode) && setShowClusterOverlay && (
                     <div className={`${feildsetStyles} flex items-center justify-between w-full p-3`}>
                         <div className="flex flex-col">
                             <span className="text-md font-semibold leading-none text-gray-900 dark:text-gray-100">Show cluster overlay</span>

--- a/src/components/ClusteringPanel.tsx
+++ b/src/components/ClusteringPanel.tsx
@@ -17,6 +17,7 @@ interface ClusteringPanelProps {
     genreColorLegend?: { id: string; name: string; color: string; isBlended?: boolean; artistCount?: number }[];
     artistClusters?: ClusterResult | null;
     clusteringInProgress?: boolean;
+    collectionMode?: boolean;
 }
 
 export default function ClusteringPanel({ 
@@ -29,7 +30,8 @@ export default function ClusteringPanel({
     setArtistColorMode,
     genreColorLegend,
     artistClusters,
-    clusteringInProgress
+    clusteringInProgress,
+    collectionMode
 }: ClusteringPanelProps) {
 
     const genreOptions = [
@@ -40,8 +42,12 @@ export default function ClusteringPanel({
 
     const artistOptions = [
         { id: "similarArtists", label: "Similar Artists", description: "Uses the existing artist network structure to find communities. Artists connected by similar artist links form clusters." },
-        // { id: "hybrid", label: "Hybrid", description: "Combines vector-based similarity with the artist network to form more robust communities." },
         { id: "popularity", label: "Popularity", description: "Arranges artists in concentric rings by listener count. Popular artists at center, underground at outer ring." },
+        ...(collectionMode ? [{
+            id: "genre",
+            label: "By Genre",
+            description: "Groups your liked artists into clusters by their primary genre — Rock, Electronic, Hip-Hop, and so on. Same-genre artists are physically pulled together.",
+        }] : []),
     ];
 
     const options = graphType === 'genres' ? genreOptions : artistOptions;

--- a/src/components/ClusteringPanel.tsx
+++ b/src/components/ClusteringPanel.tsx
@@ -18,20 +18,24 @@ interface ClusteringPanelProps {
     artistClusters?: ClusterResult | null;
     clusteringInProgress?: boolean;
     collectionMode?: boolean;
+    showClusterOverlay?: boolean;
+    setShowClusterOverlay?: (v: boolean) => void;
 }
 
-export default function ClusteringPanel({ 
-    graphType, 
-    clusterMode, 
-    setClusterMode, 
-    dagMode, 
+export default function ClusteringPanel({
+    graphType,
+    clusterMode,
+    setClusterMode,
+    dagMode,
     setDagMode,
     artistColorMode,
     setArtistColorMode,
     genreColorLegend,
     artistClusters,
     clusteringInProgress,
-    collectionMode
+    collectionMode,
+    showClusterOverlay,
+    setShowClusterOverlay,
 }: ClusteringPanelProps) {
 
     const genreOptions = [
@@ -121,6 +125,15 @@ export default function ClusteringPanel({
                         </motion.div>
                     ))}
                 </RadioGroup>
+                {graphType === 'artists' && clusterMode === 'genre' && setShowClusterOverlay && (
+                    <div className={`${feildsetStyles} flex items-center justify-between w-full p-3`}>
+                        <div className="flex flex-col">
+                            <span className="text-md font-semibold leading-none text-gray-900 dark:text-gray-100">Show cluster overlay</span>
+                            <span className="text-sm text-muted-foreground mt-1">Draw genre region hulls on the graph.</span>
+                        </div>
+                        <Switch checked={showClusterOverlay ?? true} onCheckedChange={setShowClusterOverlay} />
+                    </div>
+                )}
                 {graphType === 'artists' && artistColorMode !== undefined && setArtistColorMode && (
                     <>
                         <div className={`${feildsetStyles} flex items-center justify-between w-full p-3 pt-3`}>

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -1,6 +1,7 @@
 import {
   forwardRef,
   memo,
+  useCallback,
   useEffect,
   useImperativeHandle,
   useMemo,
@@ -87,6 +88,195 @@ export type NodeRenderer<T> = (ctx: NodeRenderContext<T>) => void;
 export type SelectionRenderer<T> = (ctx: SelectionRenderContext<T>) => void;
 export type LabelRenderer<T> = (ctx: LabelRenderContext<T>) => void;
 
+export interface ClusterOverlay {
+  id: string;
+  name: string;
+  color: string;
+  nodeIds: Set<string>;
+}
+
+// --- Cluster hull drawing helpers ---
+
+function hexToRgba(hex: string, alpha: number): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `rgba(${r},${g},${b},${alpha})`;
+}
+
+function cross2d(O: [number, number], A: [number, number], B: [number, number]): number {
+  return (A[0] - O[0]) * (B[1] - O[1]) - (A[1] - O[1]) * (B[0] - O[0]);
+}
+
+function computeConvexHull(pts: [number, number][]): [number, number][] {
+  const n = pts.length;
+  if (n < 2) return [...pts];
+  const sorted = [...pts].sort((a, b) => a[0] !== b[0] ? a[0] - b[0] : a[1] - b[1]);
+  const lower: [number, number][] = [];
+  for (const p of sorted) {
+    while (lower.length >= 2 && cross2d(lower[lower.length - 2], lower[lower.length - 1], p) <= 0) lower.pop();
+    lower.push(p);
+  }
+  const upper: [number, number][] = [];
+  for (let i = n - 1; i >= 0; i--) {
+    const p = sorted[i];
+    while (upper.length >= 2 && cross2d(upper[upper.length - 2], upper[upper.length - 1], p) <= 0) upper.pop();
+    upper.push(p);
+  }
+  lower.pop();
+  upper.pop();
+  return [...lower, ...upper];
+}
+
+// Smooth polygon via midpoint-quadratic-bezier (round corners without external deps)
+function drawSmoothPolygon(ctx: CanvasRenderingContext2D, pts: [number, number][]): void {
+  const n = pts.length;
+  if (n === 0) return;
+  const mid = (a: [number, number], b: [number, number]): [number, number] => [(a[0] + b[0]) / 2, (a[1] + b[1]) / 2];
+  const start = mid(pts[n - 1], pts[0]);
+  ctx.moveTo(start[0], start[1]);
+  for (let i = 0; i < n; i++) {
+    const curr = pts[i];
+    const next = pts[(i + 1) % n];
+    const m = mid(curr, next);
+    ctx.quadraticCurveTo(curr[0], curr[1], m[0], m[1]);
+  }
+  ctx.closePath();
+}
+
+type NodePosEntry = { x?: number; y?: number; radius: number };
+
+function buildClusterShape(
+  positions: [number, number][],
+  padding: number,
+  cx: number,
+  cy: number,
+): { kind: 'circle'; x: number; y: number; r: number } | { kind: 'poly'; pts: [number, number][] } {
+  if (positions.length === 1) {
+    return { kind: 'circle', x: positions[0][0], y: positions[0][1], r: padding };
+  }
+  if (positions.length === 2) {
+    const dx = positions[1][0] - positions[0][0];
+    const dy = positions[1][1] - positions[0][1];
+    const len = Math.sqrt(dx * dx + dy * dy) || 1;
+    const nx = (-dy / len) * padding;
+    const ny = (dx / len) * padding;
+    const ax = positions[0][0] - (dx / len) * padding;
+    const ay = positions[0][1] - (dy / len) * padding;
+    const bx = positions[1][0] + (dx / len) * padding;
+    const by = positions[1][1] + (dy / len) * padding;
+    return {
+      kind: 'poly',
+      pts: [
+        [ax + nx, ay + ny],
+        [bx + nx, by + ny],
+        [bx - nx, by - ny],
+        [ax - nx, ay - ny],
+      ],
+    };
+  }
+  const hull = computeConvexHull(positions);
+  const expanded: [number, number][] = hull.map(p => {
+    const dx = p[0] - cx;
+    const dy = p[1] - cy;
+    const len = Math.sqrt(dx * dx + dy * dy);
+    if (len < 1e-6) return [p[0] + padding, p[1]] as [number, number];
+    return [p[0] + (dx / len) * padding, p[1] + (dy / len) * padding] as [number, number];
+  });
+  return { kind: 'poly', pts: expanded };
+}
+
+function traceClusterShape(ctx: CanvasRenderingContext2D, shape: ReturnType<typeof buildClusterShape>): void {
+  ctx.beginPath();
+  if (shape.kind === 'circle') {
+    ctx.arc(shape.x, shape.y, shape.r, 0, 2 * Math.PI);
+  } else {
+    drawSmoothPolygon(ctx, shape.pts);
+  }
+}
+
+const CLUSTER_HULL_PADDING = 48;
+const CLUSTER_LABEL_SCREEN_PX = 13;
+const CLUSTER_LABEL_STROKE_SCREEN_PX = 1.5;
+
+function drawClusterHulls(
+  ctx: CanvasRenderingContext2D,
+  overlays: ClusterOverlay[],
+  nodeMap: Map<string, NodePosEntry>,
+  globalScale: number,
+): void {
+  for (const overlay of overlays) {
+    const positions: [number, number][] = [];
+    for (const id of overlay.nodeIds) {
+      const node = nodeMap.get(id);
+      if (node?.x !== undefined && node.y !== undefined) {
+        positions.push([node.x, node.y]);
+      }
+    }
+    if (positions.length === 0) continue;
+
+    const cx = positions.reduce((s, p) => s + p[0], 0) / positions.length;
+    const cy = positions.reduce((s, p) => s + p[1], 0) / positions.length;
+    const shape = buildClusterShape(positions, CLUSTER_HULL_PADDING, cx, cy);
+
+    let fillColor: string;
+    let strokeColor: string;
+    try {
+      fillColor = hexToRgba(overlay.color, 0.1);
+      strokeColor = hexToRgba(overlay.color, 0.4);
+    } catch {
+      fillColor = overlay.color + '1A';
+      strokeColor = overlay.color + '66';
+    }
+
+    traceClusterShape(ctx, shape);
+    ctx.fillStyle = fillColor;
+    ctx.fill();
+    ctx.strokeStyle = strokeColor;
+    ctx.lineWidth = CLUSTER_LABEL_STROKE_SCREEN_PX / globalScale;
+    ctx.stroke();
+  }
+}
+
+function drawClusterLabels(
+  ctx: CanvasRenderingContext2D,
+  overlays: ClusterOverlay[],
+  nodeMap: Map<string, NodePosEntry>,
+  globalScale: number,
+): void {
+  const fontSize = CLUSTER_LABEL_SCREEN_PX / globalScale;
+
+  for (const overlay of overlays) {
+    const positions: [number, number][] = [];
+    for (const id of overlay.nodeIds) {
+      const node = nodeMap.get(id);
+      if (node?.x !== undefined && node.y !== undefined) {
+        positions.push([node.x, node.y]);
+      }
+    }
+    if (positions.length === 0) continue;
+
+    const cx = positions.reduce((s, p) => s + p[0], 0) / positions.length;
+    const minY = Math.min(...positions.map(p => p[1]));
+    const labelY = minY - CLUSTER_HULL_PADDING - fontSize * 0.7;
+
+    let labelColor: string;
+    try {
+      labelColor = hexToRgba(overlay.color, 0.85);
+    } catch {
+      labelColor = overlay.color;
+    }
+
+    ctx.save();
+    ctx.font = `600 ${fontSize}px Inter, system-ui, sans-serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillStyle = labelColor;
+    ctx.fillText(overlay.name, cx, labelY);
+    ctx.restore();
+  }
+}
+
 export interface GraphProps<T, L extends SharedGraphLink> {
   nodes: SharedGraphNode<T>[];
   links: L[];
@@ -121,6 +311,8 @@ export interface GraphProps<T, L extends SharedGraphLink> {
     nodeToRadius: Map<string, number>;
     strength?: number;
   };
+  // Cluster hull overlays (genre mode)
+  clusterOverlays?: ClusterOverlay[];
 }
 
 type PreparedNode<T> = SharedGraphNode<T> & { x?: number; y?: number };
@@ -192,6 +384,7 @@ const Graph = forwardRef(function GraphInner<
     disableDimming = false,
     priorityLabelIds: priorityLabelIdsProp,
     radialLayout,
+    clusterOverlays,
   }: GraphProps<T, L>,
   ref: Ref<GraphHandle>,
 ) {
@@ -200,6 +393,7 @@ const Graph = forwardRef(function GraphInner<
   const zoomRef = useRef<number>(1);
   const showNodesRef = useRef<boolean>(showNodes);
   const showLinksRef = useRef<boolean>(showLinks);
+  const clusterOverlaysRef = useRef<ClusterOverlay[] | undefined>(undefined);
   const { resolvedTheme } = useTheme();
   const { state: sidebarState } = useSidebar();
   const sidebarExpanded = sidebarState === "expanded";
@@ -227,6 +421,10 @@ const Graph = forwardRef(function GraphInner<
     showNodesRef.current = showNodes;
     showLinksRef.current = showLinks;
   }, [showNodes, showLinks]);
+
+  useEffect(() => {
+    clusterOverlaysRef.current = clusterOverlays;
+  }, [clusterOverlays]);
 
   // Convert display control values to usable ranges (all centered at 50 = 1.0x)
   const nodeScaleFactor = useMemo(() => {
@@ -693,6 +891,26 @@ const Graph = forwardRef(function GraphInner<
     };
   }, [disableDimming]);
 
+  const handleRenderFramePre = useCallback((ctx: CanvasRenderingContext2D, globalScale: number) => {
+    const overlays = clusterOverlaysRef.current;
+    if (!overlays?.length) return;
+    const nodes = preparedDataRef.current?.nodes;
+    if (!nodes?.length) return;
+    const nodeMap = new Map<string, NodePosEntry>();
+    for (const n of nodes) nodeMap.set(n.id, n);
+    drawClusterHulls(ctx, overlays, nodeMap, globalScale);
+  }, []);
+
+  const handleRenderFramePost = useCallback((ctx: CanvasRenderingContext2D, globalScale: number) => {
+    const overlays = clusterOverlaysRef.current;
+    if (!overlays?.length) return;
+    const nodes = preparedDataRef.current?.nodes;
+    if (!nodes?.length) return;
+    const nodeMap = new Map<string, NodePosEntry>();
+    for (const n of nodes) nodeMap.set(n.id, n);
+    drawClusterLabels(ctx, overlays, nodeMap, globalScale);
+  }, []);
+
   return (
     <div
       ref={containerRef}
@@ -907,6 +1125,8 @@ const Graph = forwardRef(function GraphInner<
           ctx.fill();
         }}
         nodeVal={(node) => node.radius}
+        onRenderFramePre={handleRenderFramePre}
+        onRenderFramePost={handleRenderFramePost}
       />
       </div>
     </div>

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -272,6 +272,11 @@ function drawClusterLabels(
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
     ctx.fillStyle = labelColor;
+    // Add shadow for contrast (same as node labels)
+    ctx.shadowColor = 'rgba(0, 0, 0, 0.8)';
+    ctx.shadowBlur = 4;
+    ctx.shadowOffsetX = 0;
+    ctx.shadowOffsetY = 0;
     ctx.fillText(overlay.name, cx, labelY);
     ctx.restore();
   }

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -197,7 +197,9 @@ function traceClusterShape(ctx: CanvasRenderingContext2D, shape: ReturnType<type
 
 const CLUSTER_HULL_PADDING = 48;
 const CLUSTER_LABEL_SCREEN_PX = 13;
-const CLUSTER_LABEL_STROKE_SCREEN_PX = 1.5;
+const CLUSTER_LABEL_STROKE_SCREEN_PX = 1.2;
+const CLUSTER_LABEL_MIN_NODES = 1;
+const CLUSTER_LABEL_MAX_NODES_FOR_SCALE = 40;
 
 function drawClusterHulls(
   ctx: CanvasRenderingContext2D,
@@ -219,22 +221,35 @@ function drawClusterHulls(
     const cy = positions.reduce((s, p) => s + p[1], 0) / positions.length;
     const shape = buildClusterShape(positions, CLUSTER_HULL_PADDING, cx, cy);
 
-    let fillColor: string;
     let strokeColor: string;
+    let r: number, g: number, b: number;
     try {
-      fillColor = hexToRgba(overlay.color, 0.1);
-      strokeColor = hexToRgba(overlay.color, 0.4);
+      r = parseInt(overlay.color.slice(1, 3), 16);
+      g = parseInt(overlay.color.slice(3, 5), 16);
+      b = parseInt(overlay.color.slice(5, 7), 16);
+      strokeColor = hexToRgba(overlay.color, 0.2);
     } catch {
-      fillColor = overlay.color + '1A';
-      strokeColor = overlay.color + '66';
+      r = 128; g = 128; b = 128;
+      strokeColor = overlay.color + '33';
     }
 
+    // Radial gradient: transparent center fading to slight color at edges
+    const radius = shape.kind === 'circle'
+      ? shape.r
+      : Math.max(...shape.pts.map(p => Math.hypot(p[0] - cx, p[1] - cy)));
+    const grad = ctx.createRadialGradient(cx, cy, 0, cx, cy, radius + CLUSTER_HULL_PADDING);
+    grad.addColorStop(0, `rgba(${r},${g},${b},0)`);
+    grad.addColorStop(0.6, `rgba(${r},${g},${b},0.02)`);
+    grad.addColorStop(1, `rgba(${r},${g},${b},0.07)`);
+
     traceClusterShape(ctx, shape);
-    ctx.fillStyle = fillColor;
+    ctx.fillStyle = grad;
     ctx.fill();
     ctx.strokeStyle = strokeColor;
     ctx.lineWidth = CLUSTER_LABEL_STROKE_SCREEN_PX / globalScale;
+    ctx.setLineDash([4 / globalScale, 6 / globalScale]);
     ctx.stroke();
+    ctx.setLineDash([]);
   }
 }
 
@@ -244,7 +259,7 @@ function drawClusterLabels(
   nodeMap: Map<string, NodePosEntry>,
   globalScale: number,
 ): void {
-  const fontSize = CLUSTER_LABEL_SCREEN_PX / globalScale;
+  const baseFontSize = CLUSTER_LABEL_SCREEN_PX / globalScale;
 
   for (const overlay of overlays) {
     const positions: [number, number][] = [];
@@ -254,7 +269,11 @@ function drawClusterLabels(
         positions.push([node.x, node.y]);
       }
     }
-    if (positions.length === 0) continue;
+    if (positions.length < CLUSTER_LABEL_MIN_NODES) continue;
+
+    // Scale font: small clusters get ~70% of base, large clusters get up to 140%
+    const t = Math.min(1, (positions.length - CLUSTER_LABEL_MIN_NODES) / (CLUSTER_LABEL_MAX_NODES_FOR_SCALE - CLUSTER_LABEL_MIN_NODES));
+    const fontSize = baseFontSize * (0.7 + t * 0.7);
 
     const cx = positions.reduce((s, p) => s + p[0], 0) / positions.length;
     const minY = Math.min(...positions.map(p => p[1]));
@@ -272,7 +291,6 @@ function drawClusterLabels(
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
     ctx.fillStyle = labelColor;
-    // Add shadow for contrast (same as node labels)
     ctx.shadowColor = 'rgba(0, 0, 0, 0.8)';
     ctx.shadowBlur = 4;
     ctx.shadowOffsetX = 0;

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -711,7 +711,7 @@ const Graph = forwardRef(function GraphInner<
     // Charge force: nodes repel each other (D3 default is -30)
     // More negative = stronger repulsion/more spread out, Less negative = nodes closer together
     // KEY FIX: Reducing from -200 to -100 greatly reduced the "floating outward" drag effect
-    fg.d3Force("charge")?.strength(dagMode ? -1230 : -120);
+    fg.d3Force("charge")?.strength(dagMode ? -1230 : -190);
 
     // Link force: connected nodes attract each other
     const linkForce = fg.d3Force("link") as d3.ForceLink<PreparedNode<T>, L> | undefined;
@@ -946,7 +946,7 @@ const Graph = forwardRef(function GraphInner<
         dagLevelDistance={dagMode ? 200 : undefined}
         // How quickly the simulation "cools down" (D3 default is 0.0228)
         // Higher = faster settling but less accurate layout, Lower = slower but more precise
-        d3AlphaDecay={0.01}
+        d3AlphaDecay={0.05}
         // Friction/damping on node velocity (D3 default is 0.4, using slightly higher for stability)
         // Higher = nodes stop faster/less drift, Lower = more fluid movement
         d3VelocityDecay={0.4}

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -424,6 +424,9 @@ const Graph = forwardRef(function GraphInner<
 
   useEffect(() => {
     clusterOverlaysRef.current = clusterOverlays;
+    // autoPauseRedraw stops the canvas when the sim is idle, so poke it to
+    // repaint after the overlay data changes (on/off toggle, data update, etc.)
+    fgRef.current?.resumeAnimation?.();
   }, [clusterOverlays]);
 
   // Convert display control values to usable ranges (all centered at 50 = 1.0x)

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -198,8 +198,6 @@ function traceClusterShape(ctx: CanvasRenderingContext2D, shape: ReturnType<type
 const CLUSTER_HULL_PADDING = 48;
 const CLUSTER_LABEL_SCREEN_PX = 13;
 const CLUSTER_LABEL_STROKE_SCREEN_PX = 1.2;
-const CLUSTER_LABEL_MIN_NODES = 1;
-const CLUSTER_LABEL_MAX_NODES_FOR_SCALE = 40;
 
 function drawClusterHulls(
   ctx: CanvasRenderingContext2D,
@@ -259,7 +257,7 @@ function drawClusterLabels(
   nodeMap: Map<string, NodePosEntry>,
   globalScale: number,
 ): void {
-  const baseFontSize = CLUSTER_LABEL_SCREEN_PX / globalScale;
+  const fontSize = CLUSTER_LABEL_SCREEN_PX / globalScale;
 
   for (const overlay of overlays) {
     const positions: [number, number][] = [];
@@ -269,11 +267,7 @@ function drawClusterLabels(
         positions.push([node.x, node.y]);
       }
     }
-    if (positions.length < CLUSTER_LABEL_MIN_NODES) continue;
-
-    // Scale font: small clusters get ~70% of base, large clusters get up to 140%
-    const t = Math.min(1, (positions.length - CLUSTER_LABEL_MIN_NODES) / (CLUSTER_LABEL_MAX_NODES_FOR_SCALE - CLUSTER_LABEL_MIN_NODES));
-    const fontSize = baseFontSize * (0.7 + t * 0.7);
+    if (positions.length === 0) continue;
 
     const cx = positions.reduce((s, p) => s + p[0], 0) / positions.length;
     const minY = Math.min(...positions.map(p => p[1]));

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -990,7 +990,7 @@ const Graph = forwardRef(function GraphInner<
               const target = typeof link.target === "string" ? link.target : (link.target as NodeObject)?.id;
               return source === effectiveSelectedId || target === effectiveSelectedId ? 2 : 0.3;
             })()
-          ) : 0.5; // Reduced for less visual noise
+          ) : 0.8; // Reduced for less visual noise
           return baseWidth * linkThicknessScale;
         }}
         linkCurvature={dagMode ? 0 : linkCurvatureValue}

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -808,6 +808,61 @@ const Graph = forwardRef(function GraphInner<
     }
   }, [dataSignature, dagMode, preparedData, selectedId, show, radialLayout]);
 
+  // Cluster centroid force: pulls every node toward its cluster's live centroid each simulation tick.
+  // Uses the same nodeIds that determine cluster color, so the force is always consistent with the overlay.
+  // Runs in a separate effect so it can update independently of the main data signature.
+  useEffect(() => {
+    if (!show || !fgRef.current) return;
+    const fg = fgRef.current;
+
+    if (clusterOverlays && clusterOverlays.length > 0 && !radialLayout?.enabled) {
+      const nodeToClusterId = new Map<string, string>();
+      clusterOverlays.forEach(overlay => {
+        overlay.nodeIds.forEach(nodeId => nodeToClusterId.set(nodeId, overlay.id));
+      });
+
+      const CLUSTER_STRENGTH = 0.12;
+      const simNodes: any[] = [];
+
+      const centroidForce = Object.assign(
+        function(alpha: number) {
+          const centroids = new Map<string, { x: number; y: number; count: number }>();
+          simNodes.forEach(node => {
+            const cid = nodeToClusterId.get(node.id);
+            if (cid === undefined) return;
+            let c = centroids.get(cid);
+            if (!c) { c = { x: 0, y: 0, count: 0 }; centroids.set(cid, c); }
+            c.x += node.x ?? 0;
+            c.y += node.y ?? 0;
+            c.count++;
+          });
+          centroids.forEach(c => { c.x /= c.count; c.y /= c.count; });
+
+          simNodes.forEach(node => {
+            const cid = nodeToClusterId.get(node.id);
+            if (cid === undefined) return;
+            const centroid = centroids.get(cid);
+            if (!centroid) return;
+            node.vx = (node.vx ?? 0) - (node.x - centroid.x) * alpha * CLUSTER_STRENGTH;
+            node.vy = (node.vy ?? 0) - (node.y - centroid.y) * alpha * CLUSTER_STRENGTH;
+          });
+        },
+        {
+          initialize(nodes: any[]) {
+            simNodes.length = 0;
+            simNodes.push(...nodes);
+          },
+        }
+      );
+
+      fg.d3Force('cluster-centroid', centroidForce);
+    } else {
+      fg.d3Force('cluster-centroid', null);
+    }
+
+    fg.d3ReheatSimulation?.();
+  }, [clusterOverlays, radialLayout, show]);
+
   useEffect(() => {
     if (!autoFocus || !show || !selectedId || !fgRef.current) return;
     const node = preparedData.nodes.find((n) => n.id === selectedId);

--- a/src/components/Graph/README.md
+++ b/src/components/Graph/README.md
@@ -33,6 +33,7 @@ There is no separate Collections graph component. Collection mode uses the artis
 - Labels fade in/out based on zoom and optional priority label logic.
 - Popularity clustering can enable a radial layout (concentric rings) via `d3.forceRadial`.
 - "By Genre" clustering (collection mode only) groups liked artists by root genre. Genre assignment is pre-computed in App.tsx via `artistGenreAssignments` useMemo and passed to `ClusteringEngine` as `genreAssignments`/`genreColors`/`genreNames`. Intra-genre links use KNN tag-vector similarity for force-directed pull.
+- When clustering by genre, `ClusterOverlay` blobs are drawn on the canvas via `onRenderFramePre` (filled convex hull) and `onRenderFramePost` (cluster name label above the hull). The overlay data flows: `artistClusters` → `artistClusterOverlays` memo in App.tsx → `ArtistsForceGraph.clusterOverlays` → `Graph.clusterOverlays`. The hull uses an inline Graham-scan convex hull with outward padding expansion and smooth quadratic-bezier edges.
 
 ## Entry Points Used by the App
 

--- a/src/components/Graph/README.md
+++ b/src/components/Graph/README.md
@@ -32,6 +32,7 @@ There is no separate Collections graph component. Collection mode uses the artis
 - A data signature is used to reheat the simulation only when node/link topology changes.
 - Labels fade in/out based on zoom and optional priority label logic.
 - Popularity clustering can enable a radial layout (concentric rings) via `d3.forceRadial`.
+- "By Genre" clustering (collection mode only) groups liked artists by root genre. Genre assignment is pre-computed in App.tsx via `artistGenreAssignments` useMemo and passed to `ClusteringEngine` as `genreAssignments`/`genreColors`/`genreNames`. Intra-genre links use KNN tag-vector similarity for force-directed pull.
 
 ## Entry Points Used by the App
 

--- a/src/components/Graph/graphStyle.ts
+++ b/src/components/Graph/graphStyle.ts
@@ -292,7 +292,7 @@ export function drawSelectedNodeFill(
 
 // Default node radius bounds
 export const DEFAULT_MIN_RADIUS = 3;
-export const DEFAULT_MAX_RADIUS = 35;
+export const DEFAULT_MAX_RADIUS = 25;
 // Exponent for node size scaling (higher = more dramatic size differences)
 export const NODE_SIZE_EXPONENT = 2;
 

--- a/src/components/Graph/index.ts
+++ b/src/components/Graph/index.ts
@@ -10,4 +10,5 @@ export type {
   NodeRenderer,
   SelectionRenderer,
   LabelRenderer,
+  ClusterOverlay,
 } from './Graph';

--- a/src/lib/ClusteringEngine.ts
+++ b/src/lib/ClusteringEngine.ts
@@ -5,7 +5,7 @@ import louvain from 'graphology-communities-louvain';
 import { buildNormalizedLocationMap, calculateLocationSimilarity } from './locationNormalization';
 import { getClusterColor, DEFAULT_DARK_NODE_COLOR, DEFAULT_LIGHT_NODE_COLOR } from "@/lib/colors";
 
-export type ClusteringMethod = 'similarArtists' | 'hybrid' | 'popularity' | 'genre';
+export type ClusteringMethod = 'similarArtists' | 'byTags' | 'popularity' | 'genre';
 
 export interface ClusterResult {
   method: ClusteringMethod;
@@ -35,7 +35,7 @@ export interface Cluster {
 export interface ClusteringOptions {
   method: ClusteringMethod;
   resolution?: number;  // For Louvain
-  hybridWeights?: {
+  tagWeights?: {
     vectors: number;
     louvain: number;
     location: number;  // Weight for location-based similarity (default: 0.2)
@@ -99,8 +99,8 @@ export class ClusteringEngine {
     switch (options.method) {
       case 'similarArtists':
         return this.clusterByLouvain(options.resolution || 1.0);
-      case 'hybrid':
-        return this.clusterHybrid(options.resolution || 1.0, options.hybridWeights, kNeighbors, minSimilarity);
+      case 'byTags':
+        return this.clusterByTags(options.resolution || 1.0, options.tagWeights, kNeighbors, minSimilarity);
       case 'popularity':
         return this.clusterByListeners();
       case 'genre':
@@ -208,8 +208,8 @@ export class ClusteringEngine {
     return this.formatLouvainClusters(communities, 'similarArtists', networkSim, minLinkWeight);
   }
 
-  // 3. HYBRID CLUSTERING - Louvain with combined weighted edges
-  private clusterHybrid(
+  // 3. BY TAGS CLUSTERING - Louvain with combined weighted edges
+  private clusterByTags(
     resolution: number,
     weights = { vectors: 0.6, louvain: 0.4, location: 0.3 },
     kNeighbors: number = 15,
@@ -281,8 +281,8 @@ export class ClusteringEngine {
       penalizedSim.set(key, sim * multiplier);
     });
 
-    //console.log(`[hybrid] Combined similarities: vectors=${vectorSim.size}, network=${networkSim.size}`);
-    //console.log(`[hybrid] Location penalties applied: same=${penaltyStats.same}, region=${penaltyStats.region}, different=${penaltyStats.different}`);
+    //console.log(`[byTags] Combined similarities: vectors=${vectorSim.size}, network=${networkSim.size}`);
+    //console.log(`[byTags] Location penalties applied: same=${penaltyStats.same}, region=${penaltyStats.region}, different=${penaltyStats.different}`);
 
     // Filter out weak similarities to reduce graph complexity
     // After location penalty, more edges will fall below threshold
@@ -298,9 +298,9 @@ export class ClusteringEngine {
       }
     });
 
-    //console.log(`[hybrid] Filtered from ${penalizedSim.size} to ${filteredCombinedSim.size} edges (min weight: ${minCombinedWeight.toFixed(3)})`);
+    //console.log(`[byTags] Filtered from ${penalizedSim.size} to ${filteredCombinedSim.size} edges (min weight: ${minCombinedWeight.toFixed(3)})`);
 
-    // Ensure each artist has at least one edge in the hybrid graph.
+    // Ensure each artist has at least one edge in the byTags graph.
     const degreeByArtist = new Map<string, number>();
     this.artists.forEach(artist => {
       degreeByArtist.set(artist.id, 0);
@@ -383,7 +383,7 @@ export class ClusteringEngine {
     const communities = louvain(graph, { resolution, randomWalk: false });
 
     // Reuse artistCount from above
-    return this.formatLouvainClusters(communities, 'hybrid', filteredCombinedSim, minCombinedWeight);
+    return this.formatLouvainClusters(communities, 'byTags', filteredCombinedSim, minCombinedWeight);
   }
 
   // 4. POPULARITY CLUSTERING - Dynamic percentile-based popularity tiers
@@ -465,7 +465,7 @@ export class ClusteringEngine {
       artistToCluster.set(artist.id, clusterId);
     });
 
-    // Reuse tag-vector KNN similarity from hybrid for intra-genre link generation.
+    // Reuse tag-vector KNN similarity from byTags for intra-genre link generation.
     // mutualOnly=false gives more edges within the (smaller) genre subsets without bees-nest density.
     const tagSimilarities = this.calculateTagSimilarities(10, 0.15, false);
 
@@ -627,7 +627,7 @@ export class ClusteringEngine {
     // Adaptive link weight threshold based on method and graph size
     const artistCount = this.artists.length;
     const minLinkWeight = minLinkWeightOverride ?? (
-      method === 'hybrid' && artistCount > 1000
+      method === 'byTags' && artistCount > 1000
         ? 0.25  // Higher threshold for expensive methods on large graphs
         : 0.2   // Standard threshold
     );
@@ -661,7 +661,7 @@ export class ClusteringEngine {
   private getClusterLabel(method: ClusteringMethod): string {
     switch (method) {
       case 'similarArtists': return 'Similar Artists';
-      case 'hybrid': return 'Hybrid';
+      case 'byTags': return 'By Tags';
       case 'popularity': return 'Popularity';
       case 'genre': return 'Genre';
       default: return 'Similar Artists';

--- a/src/lib/ClusteringEngine.ts
+++ b/src/lib/ClusteringEngine.ts
@@ -3,9 +3,9 @@ import { ARTIST_LISTENER_TIERS } from '@/constants';
 import Graph from 'graphology';
 import louvain from 'graphology-communities-louvain';
 import { buildNormalizedLocationMap, calculateLocationSimilarity } from './locationNormalization';
-import {getClusterColor} from "@/lib/colors";
+import { getClusterColor, DEFAULT_DARK_NODE_COLOR, DEFAULT_LIGHT_NODE_COLOR } from "@/lib/colors";
 
-export type ClusteringMethod = 'similarArtists' | 'hybrid' | 'popularity';
+export type ClusteringMethod = 'similarArtists' | 'hybrid' | 'popularity' | 'genre';
 
 export interface ClusterResult {
   method: ClusteringMethod;
@@ -42,6 +42,10 @@ export interface ClusteringOptions {
   };
   kNeighbors?: number;  // Number of nearest neighbors to keep (default: 20)
   minSimilarity?: number;  // Minimum similarity threshold (0-1, default: 0.1)
+  // Only required when method === 'genre'
+  genreAssignments?: Map<string, string>;  // artistId -> rootGenreId
+  genreColors?: Map<string, string>;       // rootGenreId -> hex color
+  genreNames?: Map<string, string>;        // rootGenreId -> display name
 }
 
 export class ClusteringEngine {
@@ -99,6 +103,12 @@ export class ClusteringEngine {
         return this.clusterHybrid(options.resolution || 1.0, options.hybridWeights, kNeighbors, minSimilarity);
       case 'popularity':
         return this.clusterByListeners();
+      case 'genre':
+        return this.clusterByGenre(
+          options.genreAssignments ?? new Map(),
+          options.genreColors ?? new Map(),
+          options.genreNames
+        );
       default:
         return this.clusterByLouvain(options.resolution || 1.0);
     }
@@ -430,6 +440,48 @@ export class ClusteringEngine {
     };
   }
 
+  // 5. GENRE CLUSTERING - Deterministic assignment by root genre + tag-vector intra-genre links
+  private clusterByGenre(
+    genreAssignments: Map<string, string>,
+    genreColors: Map<string, string>,
+    genreNames?: Map<string, string>
+  ): ClusterResult {
+    const clusters = new Map<string, Cluster>();
+    const artistToCluster = new Map<string, string>();
+
+    // Assign each artist to its root genre cluster
+    this.artists.forEach(artist => {
+      const rootGenreId = genreAssignments.get(artist.id) ?? 'unknown';
+      const clusterId = `genre-${rootGenreId}`;
+      if (!clusters.has(clusterId)) {
+        clusters.set(clusterId, {
+          id: clusterId,
+          name: genreNames?.get(rootGenreId) ?? (rootGenreId === 'unknown' ? 'Unknown Genre' : rootGenreId),
+          artistIds: [],
+          color: genreColors.get(rootGenreId) ?? (this.isDark ? DEFAULT_DARK_NODE_COLOR : DEFAULT_LIGHT_NODE_COLOR),
+        });
+      }
+      clusters.get(clusterId)!.artistIds.push(artist.id);
+      artistToCluster.set(artist.id, clusterId);
+    });
+
+    // Reuse tag-vector KNN similarity from hybrid for intra-genre link generation.
+    // mutualOnly=false gives more edges within the (smaller) genre subsets without bees-nest density.
+    const tagSimilarities = this.calculateTagSimilarities(10, 0.15, false);
+
+    const links: Array<{ source: string; target: string; weight: number }> = [];
+    tagSimilarities.forEach((weight, key) => {
+      const [source, target] = key.split('|');
+      const sc = artistToCluster.get(source);
+      const tc = artistToCluster.get(target);
+      if (sc && tc && sc === tc) {
+        links.push({ source, target, weight });
+      }
+    });
+
+    return { method: 'genre', clusters, artistToCluster, links, stats: this.calculateStats(clusters) };
+  }
+
   // Build dynamic tiers based on percentiles of actual listener data
   private buildDynamicListenerTiers(): ListenerTier[] {
     const TIER_COUNT = 5;
@@ -611,6 +663,7 @@ export class ClusteringEngine {
       case 'similarArtists': return 'Similar Artists';
       case 'hybrid': return 'Hybrid';
       case 'popularity': return 'Popularity';
+      case 'genre': return 'Genre';
       default: return 'Similar Artists';
     }
   }

--- a/src/lib/ClusteringEngine.ts
+++ b/src/lib/ClusteringEngine.ts
@@ -107,7 +107,8 @@ export class ClusteringEngine {
         return this.clusterByGenre(
           options.genreAssignments ?? new Map(),
           options.genreColors ?? new Map(),
-          options.genreNames
+          options.genreNames,
+          minSimilarity
         );
       default:
         return this.clusterByLouvain(options.resolution || 1.0);
@@ -213,7 +214,7 @@ export class ClusteringEngine {
     resolution: number,
     weights = { vectors: 0.6, louvain: 0.4, location: 0.3 },
     kNeighbors: number = 15,
-    minSimilarity: number = 0.2
+    minSimilarity: number = 0.8
   ): ClusterResult {
     // Normalize vector/louvain weights to sum to 1.0 (location is a separate multiplier)
     const baseTotal = weights.vectors + weights.louvain;
@@ -444,7 +445,8 @@ export class ClusteringEngine {
   private clusterByGenre(
     genreAssignments: Map<string, string>,
     genreColors: Map<string, string>,
-    genreNames?: Map<string, string>
+    genreNames?: Map<string, string>,
+    minSimilarity: number = 0.9
   ): ClusterResult {
     const clusters = new Map<string, Cluster>();
     const artistToCluster = new Map<string, string>();
@@ -467,15 +469,52 @@ export class ClusteringEngine {
 
     // Reuse tag-vector KNN similarity from byTags for intra-genre link generation.
     // mutualOnly=false gives more edges within the (smaller) genre subsets without bees-nest density.
-    const tagSimilarities = this.calculateTagSimilarities(10, 0.15, false);
+    const tagSimilarities = this.calculateTagSimilarities(10, minSimilarity, false);
 
-    const links: Array<{ source: string; target: string; weight: number }> = [];
+    // Limit connections per node to reduce density in large clusters
+    const MAX_DEGREE_PER_NODE = 10;
+    const nodeConnections = new Map<string, Array<{ otherId: string; weight: number }>>();
+
+    // Collect intra-cluster connections for each node
     tagSimilarities.forEach((weight, key) => {
       const [source, target] = key.split('|');
       const sc = artistToCluster.get(source);
       const tc = artistToCluster.get(target);
-      if (sc && tc && sc === tc) {
-        links.push({ source, target, weight });
+
+      if (!sc || !tc || sc !== tc) return; // Skip inter-cluster
+
+      if (!nodeConnections.has(source)) nodeConnections.set(source, []);
+      if (!nodeConnections.has(target)) nodeConnections.set(target, []);
+
+      nodeConnections.get(source)!.push({ otherId: target, weight });
+      nodeConnections.get(target)!.push({ otherId: source, weight });
+    });
+
+    // Keep only top K connections per node by weight
+    const topConnectionsByNode = new Map<string, Set<string>>();
+    nodeConnections.forEach((connections, nodeId) => {
+      connections.sort((a, b) => b.weight - a.weight);
+      const topK = connections.slice(0, MAX_DEGREE_PER_NODE);
+      topConnectionsByNode.set(nodeId, new Set(topK.map(c => c.otherId)));
+    });
+
+    // Build final links (only if both endpoints kept each other in top K)
+    const links: Array<{ source: string; target: string; weight: number }> = [];
+    const addedEdges = new Set<string>();
+
+    tagSimilarities.forEach((weight, key) => {
+      const [source, target] = key.split('|');
+      const sc = artistToCluster.get(source);
+      const tc = artistToCluster.get(target);
+
+      if (!sc || !tc || sc !== tc) return; // Skip inter-cluster
+
+      // Only include if both nodes kept each other in their top K
+      if (topConnectionsByNode.get(source)?.has(target) && topConnectionsByNode.get(target)?.has(source)) {
+        if (!addedEdges.has(key)) {
+          links.push({ source, target, weight });
+          addedEdges.add(key);
+        }
       }
     });
 

--- a/src/lib/ClusteringEngine.ts
+++ b/src/lib/ClusteringEngine.ts
@@ -383,8 +383,12 @@ export class ClusteringEngine {
     const graph = this.buildWeightedGraph(filteredCombinedSim);
     const communities = louvain(graph, { resolution, randomWalk: false });
 
-    // Reuse artistCount from above
-    return this.formatLouvainClusters(communities, 'byTags', filteredCombinedSim, minCombinedWeight);
+    // Get initial result and apply degree capping to reduce density
+    const result = this.formatLouvainClusters(communities, 'byTags', filteredCombinedSim, minCombinedWeight);
+    if (result.links && result.links.length > 0) {
+      result.links = this.capNodeDegree(result.links, 12);
+    }
+    return result;
   }
 
   // 4. POPULARITY CLUSTERING - Dynamic percentile-based popularity tiers
@@ -471,52 +475,20 @@ export class ClusteringEngine {
     // mutualOnly=false gives more edges within the (smaller) genre subsets without bees-nest density.
     const tagSimilarities = this.calculateTagSimilarities(10, minSimilarity, false);
 
-    // Limit connections per node to reduce density in large clusters
-    const MAX_DEGREE_PER_NODE = 10;
-    const nodeConnections = new Map<string, Array<{ otherId: string; weight: number }>>();
-
-    // Collect intra-cluster connections for each node
+    // Filter to intra-cluster links
+    const intraClusterLinks: Array<{ source: string; target: string; weight: number }> = [];
     tagSimilarities.forEach((weight, key) => {
       const [source, target] = key.split('|');
       const sc = artistToCluster.get(source);
       const tc = artistToCluster.get(target);
 
-      if (!sc || !tc || sc !== tc) return; // Skip inter-cluster
-
-      if (!nodeConnections.has(source)) nodeConnections.set(source, []);
-      if (!nodeConnections.has(target)) nodeConnections.set(target, []);
-
-      nodeConnections.get(source)!.push({ otherId: target, weight });
-      nodeConnections.get(target)!.push({ otherId: source, weight });
-    });
-
-    // Keep only top K connections per node by weight
-    const topConnectionsByNode = new Map<string, Set<string>>();
-    nodeConnections.forEach((connections, nodeId) => {
-      connections.sort((a, b) => b.weight - a.weight);
-      const topK = connections.slice(0, MAX_DEGREE_PER_NODE);
-      topConnectionsByNode.set(nodeId, new Set(topK.map(c => c.otherId)));
-    });
-
-    // Build final links (only if both endpoints kept each other in top K)
-    const links: Array<{ source: string; target: string; weight: number }> = [];
-    const addedEdges = new Set<string>();
-
-    tagSimilarities.forEach((weight, key) => {
-      const [source, target] = key.split('|');
-      const sc = artistToCluster.get(source);
-      const tc = artistToCluster.get(target);
-
-      if (!sc || !tc || sc !== tc) return; // Skip inter-cluster
-
-      // Only include if both nodes kept each other in their top K
-      if (topConnectionsByNode.get(source)?.has(target) && topConnectionsByNode.get(target)?.has(source)) {
-        if (!addedEdges.has(key)) {
-          links.push({ source, target, weight });
-          addedEdges.add(key);
-        }
+      if (sc && tc && sc === tc) {
+        intraClusterLinks.push({ source, target, weight });
       }
     });
+
+    // Cap node degree to reduce density in large clusters
+    const links = this.capNodeDegree(intraClusterLinks, 10);
 
     return { method: 'genre', clusters, artistToCluster, links, stats: this.calculateStats(clusters) };
   }
@@ -793,6 +765,48 @@ export class ClusteringEngine {
   }
 
   // STATS AND UTILITIES
+
+  // Cap node degree by keeping only strongest mutual connections
+  private capNodeDegree(
+    links: Array<{ source: string; target: string; weight: number }>,
+    maxDegreePerNode: number
+  ): Array<{ source: string; target: string; weight: number }> {
+    const nodeConnections = new Map<string, Array<{ otherId: string; weight: number }>>();
+
+    // Collect connections for each node
+    links.forEach(({ source, target, weight }) => {
+      if (!nodeConnections.has(source)) nodeConnections.set(source, []);
+      if (!nodeConnections.has(target)) nodeConnections.set(target, []);
+
+      nodeConnections.get(source)!.push({ otherId: target, weight });
+      nodeConnections.get(target)!.push({ otherId: source, weight });
+    });
+
+    // Keep only top connections per node by weight
+    const topConnectionsByNode = new Map<string, Set<string>>();
+    nodeConnections.forEach((connections, nodeId) => {
+      connections.sort((a, b) => b.weight - a.weight);
+      const topK = connections.slice(0, maxDegreePerNode);
+      topConnectionsByNode.set(nodeId, new Set(topK.map(c => c.otherId)));
+    });
+
+    // Build result: only include if both endpoints kept each other
+    const result: Array<{ source: string; target: string; weight: number }> = [];
+    const addedEdges = new Set<string>();
+
+    links.forEach(({ source, target, weight }) => {
+      const key = source < target ? `${source}|${target}` : `${target}|${source}`;
+
+      if (!addedEdges.has(key) &&
+          topConnectionsByNode.get(source)?.has(target) &&
+          topConnectionsByNode.get(target)?.has(source)) {
+        result.push({ source, target, weight });
+        addedEdges.add(key);
+      }
+    });
+
+    return result;
+  }
 
   private calculateStats(clusters: Map<string, Cluster>) {
     const sizes = Array.from(clusters.values()).map(c => c.artistIds.length);

--- a/src/lib/ClusteringEngine.ts
+++ b/src/lib/ClusteringEngine.ts
@@ -107,8 +107,7 @@ export class ClusteringEngine {
         return this.clusterByGenre(
           options.genreAssignments ?? new Map(),
           options.genreColors ?? new Map(),
-          options.genreNames,
-          minSimilarity
+          options.genreNames
         );
       default:
         return this.clusterByLouvain(options.resolution || 1.0);
@@ -445,12 +444,13 @@ export class ClusteringEngine {
     };
   }
 
-  // 5. GENRE CLUSTERING - Deterministic assignment by root genre + tag-vector intra-genre links
+  // 5. GENRE CLUSTERING - Deterministic assignment by root genre + parent-genre-primary link generation
+  // Primary bond: shared parent genre (all cluster-mates get a guaranteed baseline attraction)
+  // Secondary factor: tag similarity boosts link weight for more similar artists
   private clusterByGenre(
     genreAssignments: Map<string, string>,
     genreColors: Map<string, string>,
     genreNames?: Map<string, string>,
-    minSimilarity: number = 0.9
   ): ClusterResult {
     const clusters = new Map<string, Cluster>();
     const artistToCluster = new Map<string, string>();
@@ -471,23 +471,44 @@ export class ClusteringEngine {
       artistToCluster.set(artist.id, clusterId);
     });
 
-    // Reuse tag-vector KNN similarity from byTags for intra-genre link generation.
-    // mutualOnly=false gives more edges within the (smaller) genre subsets without bees-nest density.
-    const tagSimilarities = this.calculateTagSimilarities(10, minSimilarity, false);
+    // Build tag vectors once for the whole artist set
+    const vectors = this.buildTagVectors();
 
-    // Filter to intra-cluster links
+    // For each cluster, connect each artist to its K nearest cluster-mates.
+    // Weight = BASE_WEIGHT + (1 - BASE_WEIGHT) * tagSimilarity
+    // BASE_WEIGHT guarantees every cluster-mate pair has attraction even with zero shared tags,
+    // so same-parent-genre nodes always pull together regardless of tag overlap.
+    const BASE_WEIGHT = 0.2;
+    const K_INTRA = 8;
+    const seen = new Set<string>();
     const intraClusterLinks: Array<{ source: string; target: string; weight: number }> = [];
-    tagSimilarities.forEach((weight, key) => {
-      const [source, target] = key.split('|');
-      const sc = artistToCluster.get(source);
-      const tc = artistToCluster.get(target);
 
-      if (sc && tc && sc === tc) {
-        intraClusterLinks.push({ source, target, weight });
-      }
+    clusters.forEach((cluster) => {
+      const ids = cluster.artistIds;
+      if (ids.length <= 1) return;
+
+      ids.forEach((artistId) => {
+        const vecA = vectors.get(artistId);
+        const scores: Array<{ id: string; weight: number }> = [];
+
+        ids.forEach((otherId) => {
+          if (otherId === artistId) return;
+          const vecB = vectors.get(otherId);
+          const tagSim = vecA && vecB ? this.cosineSimilarity(vecA, vecB) : 0;
+          scores.push({ id: otherId, weight: BASE_WEIGHT + (1 - BASE_WEIGHT) * tagSim });
+        });
+
+        scores.sort((a, b) => b.weight - a.weight);
+        scores.slice(0, K_INTRA).forEach(({ id, weight }) => {
+          const key = artistId < id ? `${artistId}|${id}` : `${id}|${artistId}`;
+          if (!seen.has(key)) {
+            seen.add(key);
+            intraClusterLinks.push({ source: artistId, target: id, weight });
+          }
+        });
+      });
     });
 
-    // Cap node degree to reduce density in large clusters
     const links = this.capNodeDegree(intraClusterLinks, 10);
 
     return { method: 'genre', clusters, artistToCluster, links, stats: this.calculateStats(clusters) };

--- a/src/lib/ClusteringEngine.ts
+++ b/src/lib/ClusteringEngine.ts
@@ -43,9 +43,10 @@ export interface ClusteringOptions {
   kNeighbors?: number;  // Number of nearest neighbors to keep (default: 20)
   minSimilarity?: number;  // Minimum similarity threshold (0-1, default: 0.1)
   // Only required when method === 'genre'
-  genreAssignments?: Map<string, string>;  // artistId -> rootGenreId
-  genreColors?: Map<string, string>;       // rootGenreId -> hex color
-  genreNames?: Map<string, string>;        // rootGenreId -> display name
+  genreAssignments?: Map<string, string>;       // artistId -> rootGenreId
+  genreColors?: Map<string, string>;            // rootGenreId -> hex color
+  genreNames?: Map<string, string>;             // rootGenreId -> display name
+  artistPrimaryGenreTags?: Map<string, string>; // artistId -> top genre tag name (e.g. "black metal")
 }
 
 export class ClusteringEngine {
@@ -107,7 +108,8 @@ export class ClusteringEngine {
         return this.clusterByGenre(
           options.genreAssignments ?? new Map(),
           options.genreColors ?? new Map(),
-          options.genreNames
+          options.genreNames,
+          options.artistPrimaryGenreTags
         );
       default:
         return this.clusterByLouvain(options.resolution || 1.0);
@@ -444,13 +446,16 @@ export class ClusteringEngine {
     };
   }
 
-  // 5. GENRE CLUSTERING - Deterministic assignment by root genre + parent-genre-primary link generation
-  // Primary bond: shared parent genre (all cluster-mates get a guaranteed baseline attraction)
-  // Secondary factor: tag similarity boosts link weight for more similar artists
+  // 5. GENRE CLUSTERING
+  // Bond hierarchy:
+  //   1. Shared primary genre tag (e.g. "black metal") → guaranteed link regardless of cosine sim
+  //   2. Shared parent genre (same cluster) → KNN backbone with BASE_WEIGHT floor
+  //   3. Full tag cosine similarity → boosts weight within both groups
   private clusterByGenre(
     genreAssignments: Map<string, string>,
     genreColors: Map<string, string>,
     genreNames?: Map<string, string>,
+    artistPrimaryGenreTags?: Map<string, string>,
   ): ClusterResult {
     const clusters = new Map<string, Cluster>();
     const artistToCluster = new Map<string, string>();
@@ -471,22 +476,53 @@ export class ClusteringEngine {
       artistToCluster.set(artist.id, clusterId);
     });
 
-    // Build tag vectors once for the whole artist set
     const vectors = this.buildTagVectors();
-
-    // For each cluster, connect each artist to its K nearest cluster-mates.
-    // Weight = BASE_WEIGHT + (1 - BASE_WEIGHT) * tagSimilarity
-    // BASE_WEIGHT guarantees every cluster-mate pair has attraction even with zero shared tags,
-    // so same-parent-genre nodes always pull together regardless of tag overlap.
     const BASE_WEIGHT = 0.2;
     const K_INTRA = 8;
     const seen = new Set<string>();
     const intraClusterLinks: Array<{ source: string; target: string; weight: number }> = [];
 
+    const addLink = (a: string, b: string, weight: number) => {
+      const key = a < b ? `${a}|${b}` : `${b}|${a}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        intraClusterLinks.push({ source: a, target: b, weight });
+      }
+    };
+
     clusters.forEach((cluster) => {
       const ids = cluster.artistIds;
       if (ids.length <= 1) return;
 
+      // --- Pass 1: guarantee links for artists sharing the same primary genre tag ---
+      // TF-IDF cosine sim can rank artists with the same specific genre tag (e.g. "black metal")
+      // below K_INTRA if their broader tag profiles diverge. This pass fixes that.
+      if (artistPrimaryGenreTags) {
+        const byTag = new Map<string, string[]>();
+        ids.forEach(id => {
+          const tag = artistPrimaryGenreTags.get(id);
+          if (tag) {
+            if (!byTag.has(tag)) byTag.set(tag, []);
+            byTag.get(tag)!.push(id);
+          }
+        });
+
+        byTag.forEach(tagGroup => {
+          if (tagGroup.length <= 1) return;
+          tagGroup.forEach(a => {
+            tagGroup.forEach(b => {
+              if (a >= b) return;
+              const vecA = vectors.get(a);
+              const vecB = vectors.get(b);
+              const tagSim = vecA && vecB ? this.cosineSimilarity(vecA, vecB) : 0;
+              addLink(a, b, BASE_WEIGHT + (1 - BASE_WEIGHT) * tagSim);
+            });
+          });
+        });
+      }
+
+      // --- Pass 2: KNN backbone — connect each artist to its K nearest cluster-mates ---
+      // BASE_WEIGHT floor ensures same-parent-genre nodes always attract even with zero shared tags.
       ids.forEach((artistId) => {
         const vecA = vectors.get(artistId);
         const scores: Array<{ id: string; weight: number }> = [];
@@ -499,13 +535,7 @@ export class ClusteringEngine {
         });
 
         scores.sort((a, b) => b.weight - a.weight);
-        scores.slice(0, K_INTRA).forEach(({ id, weight }) => {
-          const key = artistId < id ? `${artistId}|${id}` : `${id}|${artistId}`;
-          if (!seen.has(key)) {
-            seen.add(key);
-            intraClusterLinks.push({ source: artistId, target: id, weight });
-          }
-        });
+        scores.slice(0, K_INTRA).forEach(({ id, weight }) => addLink(artistId, id, weight));
       });
     });
 

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -4,7 +4,7 @@ This folder holds the clustering and centrality logic used by the artists/genres
 
 ## What This Module Contains
 
-- `ClusteringEngine.ts` - artist clustering methods (similarArtists, hybrid, popularity).
+- `ClusteringEngine.ts` - artist clustering methods (similarArtists, hybrid, popularity, genre).
 - `CentralityMetrics.ts` - graph centrality + lightweight helpers for priority labels.
 - `locationNormalization.ts` - normalizes location strings for clustering penalties.
 - `fixedOrderedMap.ts` - small utility used by graph data handling.
@@ -24,10 +24,11 @@ Artist[] + NodeLink[]
 ## Clustering Methods (high level)
 
 - `similarArtists`: Louvain community detection on the existing similar-artist network.
-- `hybrid`: weighted blend of tag-vector similarity + network links, with an optional location penalty.
+- `hybrid`: weighted blend of tag-vector similarity + network links, with an optional location penalty. (Currently unused in the UI — replaced by `genre` for collection mode.)
 - `popularity`: percentile-based listener tiers (used for radial layout in the UI).
+- `genre`: deterministic assignment by root genre (Rock, Electronic, etc.). Requires `genreAssignments`, `genreColors`, and `genreNames` in `ClusteringOptions`. Intra-cluster links are generated from KNN tag-vector similarity (reuses hybrid's `calculateTagSimilarities`). Only surfaced in collection mode.
 
-`popularity` returns `tierData` for concentric-ring layouts. `hybrid` uses normalized locations to penalize cross-region edges.
+`popularity` returns `tierData` for concentric-ring layouts. `genre` requires pre-computed genre maps passed from App.tsx via `ClusteringOptions`.
 
 ## Centrality
 

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -26,7 +26,7 @@ Artist[] + NodeLink[]
 - `similarArtists`: Louvain community detection on the existing similar-artist network.
 - `hybrid`: weighted blend of tag-vector similarity + network links, with an optional location penalty. (Currently unused in the UI — replaced by `genre` for collection mode.)
 - `popularity`: percentile-based listener tiers (used for radial layout in the UI).
-- `genre`: deterministic assignment by root genre (Rock, Electronic, etc.). Requires `genreAssignments`, `genreColors`, and `genreNames` in `ClusteringOptions`. Intra-cluster links are generated from KNN tag-vector similarity (reuses hybrid's `calculateTagSimilarities`). Only surfaced in collection mode.
+- `genre`: deterministic assignment by root genre (Rock, Electronic, etc.). Requires `genreAssignments`, `genreColors`, and `genreNames` in `ClusteringOptions`. Intra-cluster links use a two-factor model: shared parent genre is the primary bond (every cluster-mate gets a guaranteed `BASE_WEIGHT=0.2` attraction so same-parent nodes always pull together), and tag-vector cosine similarity boosts the weight up to 1.0 as a secondary factor. Each artist connects to its top-8 cluster-mates by this combined score. Only surfaced in collection mode.
 
 `popularity` returns `tierData` for concentric-ring layouts. `genre` requires pre-computed genre maps passed from App.tsx via `ClusteringOptions`.
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,7 +63,7 @@ export type GraphType = 'genres' | 'artists' | 'similarArtists' | 'parentGenre';
 
 export type GenreClusterMode = 'subgenre' | 'influence' | 'fusion';
 
-export type ArtistClusterMode = 'similarArtists' | 'hybrid' | 'popularity' | 'genre';
+export type ArtistClusterMode = 'similarArtists' | 'byTags' | 'popularity' | 'genre';
 
 export type LinkType = GenreClusterMode | 'similar';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,7 +63,7 @@ export type GraphType = 'genres' | 'artists' | 'similarArtists' | 'parentGenre';
 
 export type GenreClusterMode = 'subgenre' | 'influence' | 'fusion';
 
-export type ArtistClusterMode = 'similarArtists' | 'hybrid' | 'popularity';
+export type ArtistClusterMode = 'similarArtists' | 'hybrid' | 'popularity' | 'genre';
 
 export type LinkType = GenreClusterMode | 'similar';
 


### PR DESCRIPTION
## Changes
- Added "By Genre" clustering mode to the artist graph, visible only in collection mode (liked artists). Groups liked artists into root genre clusters (Rock, Electronic, Hip-Hop, etc.) using deterministic tag-based assignment — each artist goes into one cluster based on their highest-count genre tag, with a fallback to `artist.genres[0]`.
- Intra-genre links generated from KNN tag-vector similarity (reused from the existing hybrid clustering method) to physically pull same-genre artists together in the force layout. Using `mutualOnly: false` with `kNeighbors=10, minSimilarity=0.15` for collection-appropriate density.
- Cluster colors match the existing root genre color palette (same `assignRootGenreColors` call).
- Clustering method selection now sticky per view mode. Separate state and localStorage keys for:
  - `collectionArtistClusterMethod` (Collection view)
  - `exploreArtistClusterMethod` (Explore/artists view)
  - `similarArtistClusterMethod` (Similar artists view)
- `artistGenreAssignments` useMemo in App.tsx pre-computes genre assignment, color, and name maps and passes them to `ClusteringEngine` when method is `'genre'`.
- `ClusteringPanel` receives new `collectionMode` prop; "By Genre" option is conditionally appended to `artistOptions`.
- physics tweaks to cooldown collisions
- Renamed "Hybrid" clustering mode to "By Tags" for semantic clarity — groups artists by shared musical characteristics (tag-based similarity combined with network structure). Renamed internal `hybridWeights` property to `tagWeights` for consistency.
- Added "By Tags" as a clustering option in collection mode alongside "By Genre" and "Similar Artists".
- Enabled cluster overlays for genre, byTags, and popularity modes (off by default). Updated overlay toggle to work across popularity, By Genres, and By Tags clustering modes
