### PR TITLE
Similar Artist Navigation Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,6 @@ dist-ssr
 .env
 .claude
 .pr-notes.md
-.01_docs
-
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -170,6 +170,7 @@ function App() {
   const [pendingArtistGenreGraph, setPendingArtistGenreGraph] = useState<Artist | undefined>(undefined);
   const [genreTopArtistsCache, setGenreTopArtistsCache] = useState<Map<string, Artist[]>>(new Map());
   const artistImageCache = useRef<Map<string, string>>(new Map());
+  const artistObjectCache = useRef<Map<string, Artist>>(new Map());
   const [canCreateSimilarArtistGraph, setCanCreateSimilarArtistGraph] = useState<boolean>(false);
   const [genreClusterMode, setGenreClusterMode] = useState<GenreClusterMode[]>(DEFAULT_CLUSTER_MODE);
   const [artistClusterMethod, setArtistClusterMethod] = useState<ArtistClusterMode>(() => {
@@ -1570,31 +1571,38 @@ function App() {
     }
   }
 
-  // Populate image cache from all artist data sources
+  // Populate image + object caches from all artist data sources
   useEffect(() => {
-    const cache = artistImageCache.current;
+    const imgs = artistImageCache.current;
+    const objs = artistObjectCache.current;
     for (const a of currentArtists) {
-      if (a.name && a.image) cache.set(a.name, a.image as string);
+      if (a.name && a.image) imgs.set(a.name, a.image as string);
+      if (a.name) objs.set(a.name, a);
     }
   }, [currentArtists]);
 
   useEffect(() => {
-    const cache = artistImageCache.current;
+    const imgs = artistImageCache.current;
+    const objs = artistObjectCache.current;
     for (const a of similarArtists) {
-      if (a.name && a.image) cache.set(a.name, a.image as string);
+      if (a.name && a.image) imgs.set(a.name, a.image as string);
+      if (a.name) objs.set(a.name, a);
     }
   }, [similarArtists]);
 
   useEffect(() => {
-    const cache = artistImageCache.current;
+    const imgs = artistImageCache.current;
+    const objs = artistObjectCache.current;
     for (const a of (topArtists ?? [])) {
-      if (a.name && a.image) cache.set(a.name, a.image as string);
+      if (a.name && a.image) imgs.set(a.name, a.image as string);
+      if (a.name) objs.set(a.name, a);
     }
   }, [topArtists]);
 
   useEffect(() => {
-    if (selectedArtist?.name && selectedArtist.image) {
-      artistImageCache.current.set(selectedArtist.name, selectedArtist.image as string);
+    if (selectedArtist?.name) {
+      if (selectedArtist.image) artistImageCache.current.set(selectedArtist.name, selectedArtist.image as string);
+      artistObjectCache.current.set(selectedArtist.name, selectedArtist);
     }
   }, [selectedArtist]);
 
@@ -1606,6 +1614,11 @@ function App() {
 
   const getArtistByName = (name: string) => {
     return currentArtists.find((a) => a.name === name);
+  }
+
+  const getArtistColorByName = (name: string): string | undefined => {
+    const artist = artistObjectCache.current.get(name);
+    return artist ? getArtistColor(artist) : undefined;
   }
 
   const getGenreNameById = (id: string) => {
@@ -3073,6 +3086,7 @@ function App() {
                 onGenreClick={onGenreNameClick}
                 getArtistImageByName={getArtistImageByName}
                 getArtistByName={getArtistByName}
+                getArtistColorByName={getArtistColorByName}
                 genreColorMap={genreColorMap}
                 getArtistColor={getArtistColor}
                 getGenreNameById={getGenreNameById}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -169,6 +169,7 @@ function App() {
   const [currentArtistLinks, setCurrentArtistLinks] = useState<NodeLink[]>([]);
   const [pendingArtistGenreGraph, setPendingArtistGenreGraph] = useState<Artist | undefined>(undefined);
   const [genreTopArtistsCache, setGenreTopArtistsCache] = useState<Map<string, Artist[]>>(new Map());
+  const artistImageCache = useRef<Map<string, string>>(new Map());
   const [canCreateSimilarArtistGraph, setCanCreateSimilarArtistGraph] = useState<boolean>(false);
   const [genreClusterMode, setGenreClusterMode] = useState<GenreClusterMode[]>(DEFAULT_CLUSTER_MODE);
   const [artistClusterMethod, setArtistClusterMethod] = useState<ArtistClusterMode>(() => {
@@ -1569,9 +1570,37 @@ function App() {
     }
   }
 
+  // Populate image cache from all artist data sources
+  useEffect(() => {
+    const cache = artistImageCache.current;
+    for (const a of currentArtists) {
+      if (a.name && a.image) cache.set(a.name, a.image as string);
+    }
+  }, [currentArtists]);
+
+  useEffect(() => {
+    const cache = artistImageCache.current;
+    for (const a of similarArtists) {
+      if (a.name && a.image) cache.set(a.name, a.image as string);
+    }
+  }, [similarArtists]);
+
+  useEffect(() => {
+    const cache = artistImageCache.current;
+    for (const a of (topArtists ?? [])) {
+      if (a.name && a.image) cache.set(a.name, a.image as string);
+    }
+  }, [topArtists]);
+
+  useEffect(() => {
+    if (selectedArtist?.name && selectedArtist.image) {
+      artistImageCache.current.set(selectedArtist.name, selectedArtist.image as string);
+    }
+  }, [selectedArtist]);
+
   const getArtistImageByName = (name: string) => {
-    const a = currentArtists.find((x) => x.name === name);
-    const raw = a?.image as string | undefined;
+    const raw = artistImageCache.current.get(name)
+      ?? currentArtists.find((x) => x.name === name)?.image as string | undefined;
     return raw ? fixWikiImageURL(raw) : undefined;
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1152,6 +1152,8 @@ function App() {
         setCurrentArtistLinks(links);
         setGraph('similarArtists');
         setShowArtistCard(true);
+      } else if (similarArtists.length === 1) {
+        toast.error(`No similar artist data available for ${similarArtists[0].name}`);
       }
       setCanCreateSimilarArtistGraph(false);
     }
@@ -1554,11 +1556,15 @@ function App() {
     } else {
       const fetched = await fetchArtistBySearch(name);
       if (fetched) {
-        setSelectedArtist(undefined);
-        setArtistInfoToShow(fetched);
-        setShowArtistCard(true);
-        addRecentSelection(fetched);
-        updateUrl({ type: 'artist', id: fetched.id, name: fetched.name });
+        if (graph === 'similarArtists') {
+          await createSimilarArtistGraph(fetched);
+        } else {
+          setSelectedArtist(undefined);
+          setArtistInfoToShow(fetched);
+          setShowArtistCard(true);
+          addRecentSelection(fetched);
+          updateUrl({ type: 'artist', id: fetched.id, name: fetched.name });
+        }
       }
     }
   }
@@ -2008,10 +2014,6 @@ function App() {
   }
 
   const createSimilarArtistGraph = async (artistResult: Artist) => {
-    if (!artistResult.similar || artistResult.similar.length === 0) {
-      toast.error(`No similar artist data available for ${artistResult.name}`);
-      return;
-    }
     setCanCreateSimilarArtistGraph(true);
     await fetchSimilarArtists(artistResult);
     setSelectedArtistFromSearch(false);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2018,6 +2018,7 @@ function App() {
     setArtistPreviewStack([]);
     setSelectedArtist(artistResult);
     setSimilarArtistAnchor(artistResult);
+    setArtistInfoToShow(artistResult);
   }
 
   const onGenreClusterModeChange = (newMode: GenreClusterMode[]) => {
@@ -2109,14 +2110,18 @@ function App() {
       if (isBeforeArtistLoad) setIsBeforeArtistLoad(false);
       setGraph('artists');
 
-      // Restore card visibility based on selections
-      if (selectedArtist) {
-        // Prioritize showing artist card if an artist was selected
-        setArtistInfoToShow(selectedArtist);
+      // Restore card visibility.
+      // Use artistInfoToShow (what the drawer was displaying) rather than selectedArtist —
+      // navigating to an off-graph artist clears selectedArtist but keeps artistInfoToShow set.
+      if (artistInfoToShow) {
         setShowArtistCard(true);
-        // Hide genre card unless there's an active filter
         if (artistFilterGenres.length === 0) {
           setShowGenreCard(false);
+        }
+        // If the last-viewed artist isn't in the restored graph, clear selectedArtist so we
+        // don't accidentally dim every node trying to focus someone who isn't there.
+        if (selectedArtist && !artists.some(a => a.id === selectedArtist.id)) {
+          setSelectedArtist(undefined);
         }
       } else if (artistFilterGenres.length > 0) {
         // If no artist selected but there's an active filter, show genre card

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -294,6 +294,7 @@ function App() {
     artistsPlayIDsLoading,
     artistPlayIDLoadingKey,
     fetchSingleArtist,
+    fetchArtistBySearch,
     similarArtists,
     fetchSimilarArtists,
   } = useArtists(artistQueryGenreIDs, TOP_ARTISTS_TO_FETCH, artistNodeLimitType, artistNodeCount, isBeforeArtistLoad, collectionMode);
@@ -1546,10 +1547,18 @@ function App() {
     }
   };
 
-  const setArtistFromName = (name: string) => {
+  const setArtistFromName = async (name: string) => {
     const artist = currentArtists.find((a) => a.name === name);
     if (artist) {
       onArtistNodeClick(artist);
+    } else {
+      const fetched = await fetchArtistBySearch(name);
+      if (fetched) {
+        setArtistInfoToShow(fetched);
+        setShowArtistCard(true);
+        addRecentSelection(fetched);
+        updateUrl({ type: 'artist', id: fetched.id, name: fetched.name });
+      }
     }
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1554,6 +1554,7 @@ function App() {
     } else {
       const fetched = await fetchArtistBySearch(name);
       if (fetched) {
+        setSelectedArtist(undefined);
         setArtistInfoToShow(fetched);
         setShowArtistCard(true);
         addRecentSelection(fetched);
@@ -1851,6 +1852,7 @@ function App() {
 
   const onSearchArtistSelect = (artist: Artist) => {
     setAutoFocusGraph(false); // Disable auto-focus for search selections
+    setSelectedArtist(undefined);
     setSelectedArtistFromSearch(true);
     setArtistPreviewStack((prev) => {
       if (artistInfoToShow && artistInfoToShow.id !== artist.id) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1613,8 +1613,6 @@ function App() {
     const uncached = selectedArtist.similar.filter((name) => !artistImageCache.current.has(name));
     if (!uncached.length) return;
     prefetchSimilarImages(selectedArtist).then((artists) => {
-      console.log('[prefetch] returned names:', artists.map(a => a.name));
-      console.log('[prefetch] similar string names:', selectedArtist.similar);
       const newEntries: [string, string][] = [];
       for (const a of artists) {
         if (a.name && a.image) {
@@ -1622,7 +1620,6 @@ function App() {
           newEntries.push([a.name, a.image as string]);
         }
       }
-      console.log('[prefetch] newEntries cached:', newEntries.map(([n]) => n));
       if (newEntries.length) {
         setPrefetchedImageCache((prev) => {
           const next = new Map(prev);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1560,15 +1560,11 @@ function App() {
     } else {
       const fetched = await fetchArtistBySearch(name);
       if (fetched) {
-        if (graph === 'similarArtists') {
-          await createSimilarArtistGraph(fetched);
-        } else {
-          setSelectedArtist(undefined);
-          setArtistInfoToShow(fetched);
-          setShowArtistCard(true);
-          addRecentSelection(fetched);
-          updateUrl({ type: 'artist', id: fetched.id, name: fetched.name });
-        }
+        setSelectedArtist(undefined);
+        setArtistInfoToShow(fetched);
+        setShowArtistCard(true);
+        addRecentSelection(fetched);
+        updateUrl({ type: 'artist', id: fetched.id, name: fetched.name });
       }
     }
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,6 @@ import useArtists from "@/hooks/useArtists";
 import useGenres from "@/hooks/useGenres";
 import useGenreTopArtists from "@/hooks/useGenreTopArtists";
 import ArtistsForceGraph, { type GraphHandle } from "@/components/ArtistsForceGraph";
-import type { ClusterOverlay } from "@/components/Graph";
 import GenresForceGraph from "@/components/GenresForceGraph";
 import {
   Artist, ArtistClusterMode, ArtistNodeLimitType, BadDataReport, ContextAction, FindOption,
@@ -175,45 +174,15 @@ function App() {
   const artistObjectCache = useRef<Map<string, Artist>>(new Map());
   const [canCreateSimilarArtistGraph, setCanCreateSimilarArtistGraph] = useState<boolean>(false);
   const [genreClusterMode, setGenreClusterMode] = useState<GenreClusterMode[]>(DEFAULT_CLUSTER_MODE);
-  const [collectionArtistClusterMethod, setCollectionArtistClusterMethod] = useState<ArtistClusterMode>(() => {
-    // Try new key first, fall back to old key for backward compatibility
-    let stored = localStorage.getItem('collectionArtistClusterMethod');
-    if (!stored) {
-      stored = localStorage.getItem('artistClusterMethod');
-    }
+  const [artistClusterMethod, setArtistClusterMethod] = useState<ArtistClusterMode>(() => {
+    const stored = localStorage.getItem('artistClusterMethod');
     if (stored === 'louvain') {
       return 'similarArtists';
     }
     if (stored === 'listeners') {
       return 'popularity';
     }
-    if (stored === 'similarArtists' || stored === 'byTags' || stored === 'popularity' || stored === 'genre') {
-      return stored;
-    }
-    return DEFAULT_ARTIST_CLUSTER_MODE;
-  });
-  const [exploreArtistClusterMethod, setExploreArtistClusterMethod] = useState<ArtistClusterMode>(() => {
-    const stored = localStorage.getItem('exploreArtistClusterMethod');
-    if (stored === 'louvain') {
-      return 'similarArtists';
-    }
-    if (stored === 'listeners') {
-      return 'popularity';
-    }
-    if (stored === 'similarArtists' || stored === 'byTags' || stored === 'popularity' || stored === 'genre') {
-      return stored;
-    }
-    return DEFAULT_ARTIST_CLUSTER_MODE;
-  });
-  const [similarArtistClusterMethod, setSimilarArtistClusterMethod] = useState<ArtistClusterMode>(() => {
-    const stored = localStorage.getItem('similarArtistClusterMethod');
-    if (stored === 'louvain') {
-      return 'similarArtists';
-    }
-    if (stored === 'listeners') {
-      return 'popularity';
-    }
-    if (stored === 'similarArtists' || stored === 'byTags' || stored === 'popularity' || stored === 'genre') {
+    if (stored === 'similarArtists' || stored === 'hybrid' || stored === 'popularity') {
       return stored;
     }
     return DEFAULT_ARTIST_CLUSTER_MODE;
@@ -221,10 +190,6 @@ function App() {
   const [artistColorMode, setArtistColorMode] = useState<'genre' | 'cluster'>(() => {
     const stored = localStorage.getItem('artistColorMode');
     return (stored === 'cluster' ? 'cluster' : 'genre') as 'genre' | 'cluster';
-  });
-  const [showClusterOverlay, setShowClusterOverlay] = useState<boolean>(() => {
-    const stored = localStorage.getItem('showClusterOverlay');
-    return stored === null ? true : stored === 'true';
   });
   const [dagMode, setDagMode] = useState<boolean>(() => {
     const storedDagMode = localStorage.getItem('dagMode');
@@ -335,7 +300,9 @@ function App() {
     fetchArtistBySearch,
     similarArtists,
     fetchSimilarArtists,
-  } = useArtists(artistQueryGenreIDs, TOP_ARTISTS_TO_FETCH, artistNodeLimitType, artistNodeCount, isBeforeArtistLoad, collectionMode, selectedDecades);
+    prefetchSimilarImages,
+    fetchArtistByName,
+  } = useArtists(artistQueryGenreIDs, TOP_ARTISTS_TO_FETCH, artistNodeLimitType, artistNodeCount, isBeforeArtistLoad, collectionMode);
 
   // Fetch top artists for the currently displayed genre info or the active filter
   const [topArtistsGenreId, setTopArtistsGenreId] = useState<string | undefined>(undefined);
@@ -759,19 +726,14 @@ function App() {
       );
     }
 
-    if (collectionMode && collectionFilters.decades.length > 0) {
-      filtered = filtered.filter(artist => {
-        if (!artist.startDate || artist.startDate.length < 4) return false;
-        const startYear = parseInt(artist.startDate.substring(0, 4));
-        const endYear = artist.endDate && artist.endDate.length >= 4
-          ? parseInt(artist.endDate.substring(0, 4))
-          : null;
-        return collectionFilters.decades.some(decade => {
-          const decadeStart = parseInt(decade.replace('s', ''));
-          return startYear <= decadeStart + 9 && (endYear === null || endYear >= decadeStart);
-        });
-      });
-    }
+    // Apply decade filter (if any decades selected)
+    // TODO: Implement when decade data is available on artists
+    // if (collectionFilters.decades.length > 0) {
+    //   filtered = filtered.filter(artist => {
+    //     const decade = getArtistDecade(artist);
+    //     return collectionFilters.decades.includes(decade);
+    //   });
+    // }
 
     // Apply node limit - sort by the limit type and take top N
     if (filtered.length > artistNodeCount) {
@@ -813,89 +775,14 @@ function App() {
     });
   }, [graph]);
 
-  // Pre-compute per-artist root genre assignment for "By Genre" clustering (collection mode)
-  const artistGenreAssignments = useMemo((): {
-    assignments: Map<string, string>;
-    colors: Map<string, string>;
-    names: Map<string, string>;
-    primaryGenreTags: Map<string, string>;
-  } => {
-    const assignments = new Map<string, string>();
-    const colors = new Map<string, string>();
-    const names = new Map<string, string>();
-    const primaryGenreTags = new Map<string, string>();
-
-    if (!currentArtists.length || !genres.length) return { assignments, colors, names, primaryGenreTags };
-
-    const isDark = resolvedTheme === 'dark';
-    const genreById = new Map(genres.map(g => [g.id, g]));
-    const genreByName = new Map(genres.map(g => [g.name, g]));
-    const rootIdLookup = new Set(genreRoots);
-    const genreNameById = new Map(genres.map(g => [g.id, g.name]));
-
-    const globalRootArtistCount = new Map<string, number>();
-    genres.forEach(genre => {
-      if (genre.rootGenres?.length) {
-        genre.rootGenres.forEach(rootId => {
-          globalRootArtistCount.set(rootId, (globalRootArtistCount.get(rootId) ?? 0) + genre.artistCount);
-        });
-      }
-      if (rootIdLookup.has(genre.id)) {
-        globalRootArtistCount.set(genre.id, (globalRootArtistCount.get(genre.id) ?? 0) + genre.artistCount);
-      }
-    });
-    const rootColorMap = assignRootGenreColors(genreRoots, isDark, globalRootArtistCount);
-
-    currentArtists.forEach(artist => {
-      let rootGenreId: string | null = null;
-
-      if (artist.tags?.length) {
-        const genreTags = artist.tags
-          .filter(t => genreByName.has(t.name))
-          .sort((a, b) => b.count - a.count);
-        if (genreTags.length > 0) {
-          primaryGenreTags.set(artist.id, genreTags[0].name);
-          const tagGenre = genreByName.get(genreTags[0].name);
-          if (tagGenre?.rootGenres?.[0]) rootGenreId = tagGenre.rootGenres[0];
-        }
-      }
-
-      if (!rootGenreId && artist.genres?.length) {
-        const firstGenre = genreById.get(artist.genres[0]);
-        if (firstGenre?.rootGenres?.[0]) {
-          rootGenreId = firstGenre.rootGenres[0];
-        } else if (firstGenre && rootIdLookup.has(firstGenre.id)) {
-          rootGenreId = firstGenre.id;
-        }
-      }
-
-      const finalRootId = rootGenreId ?? 'unknown';
-      assignments.set(artist.id, finalRootId);
-
-      if (finalRootId !== 'unknown' && !colors.has(finalRootId)) {
-        const color = rootColorMap.get(finalRootId);
-        if (color) {
-          colors.set(finalRootId, color);
-          names.set(finalRootId, genreNameById.get(finalRootId) ?? finalRootId);
-        }
-      }
-    });
-
-    colors.set('unknown', isDark ? DEFAULT_DARK_NODE_COLOR : DEFAULT_LIGHT_NODE_COLOR);
-    names.set('unknown', 'Unknown Genre');
-
-    return { assignments, colors, names, primaryGenreTags };
-  }, [currentArtists, genres, genreRoots, resolvedTheme]);
-
   // Compute artist clusters using selected clustering method
   // Use async computation for large graphs to avoid blocking UI
   const [artistClusters, setArtistClusters] = useState<ClusterResult | null>(null);
   const [clusteringInProgress, setClusteringInProgress] = useState(false);
   const clusteringTimeoutRef = useRef<any | null>(null);
-  const clusteringGenerationRef = useRef(0);
 
   useEffect(() => {
-    if (graph !== 'artists' || !currentArtists.length) {
+    if ((graph !== 'artists' && graph !== 'similarArtists') || !currentArtists.length) {
       setArtistClusters(null);
       return;
     }
@@ -905,24 +792,7 @@ function App() {
       clearTimeout(clusteringTimeoutRef.current);
     }
 
-    // Reset clusters so the graph hides while recomputing — prevents showing nodes without
-    // edges if artists load before links (race condition on first load).
-    setArtistClusters(null);
-
     setClusteringInProgress(true);
-
-    // Select the appropriate clustering method based on the current view
-    let artistClusterMethod: ArtistClusterMode;
-    if (graph === 'similarArtists') {
-      artistClusterMethod = similarArtistClusterMethod;
-    } else if (graph === 'artists' && collectionMode) {
-      artistClusterMethod = collectionArtistClusterMethod;
-    } else {
-      artistClusterMethod = exploreArtistClusterMethod;
-    }
-    // Increment generation so any in-flight requestIdleCallback from a previous run is
-    // treated as stale and discarded (clearTimeout only cancels the debounce, not the idle callback).
-    const generation = ++clusteringGenerationRef.current;
 
     // Debounce clustering computation and run it async
     clusteringTimeoutRef.current = setTimeout(() => {
@@ -936,19 +806,12 @@ function App() {
       };
 
       scheduleClustering(() => {
-        if (clusteringGenerationRef.current !== generation) return;
         try {
           const isDark = resolvedTheme === 'dark';
           const engine = new ClusteringEngine(currentArtists, currentArtistLinks, isDark);
           const result = engine.cluster({
             method: artistClusterMethod,
             resolution: 1.0,
-            ...(artistClusterMethod === 'genre' && {
-              genreAssignments: artistGenreAssignments.assignments,
-              genreColors: artistGenreAssignments.colors,
-              genreNames: artistGenreAssignments.names,
-              artistPrimaryGenreTags: artistGenreAssignments.primaryGenreTags,
-            }),
           });
           setArtistClusters(result);
         } catch (error) {
@@ -966,7 +829,7 @@ function App() {
         clearTimeout(clusteringTimeoutRef.current);
       }
     };
-  }, [currentArtists, currentArtistLinks, graph, collectionMode, collectionArtistClusterMethod, exploreArtistClusterMethod, similarArtistClusterMethod, resolvedTheme, artistGenreAssignments]);
+  }, [currentArtists, currentArtistLinks, graph, artistClusterMethod, resolvedTheme]);
 
   // Use generated links from clustering (artists colored by parent genre)
   useEffect(() => {
@@ -1020,30 +883,6 @@ function App() {
       setFilteredArtistLinks(currentArtistLinks);
     }
   }, [artistClusters, graph, currentArtistLinks, filterArtistLinksByClusters, currentArtists]);
-
-  // Cluster hull overlays for genre, byTags, and popularity modes
-  const artistClusterOverlays = useMemo((): ClusterOverlay[] | undefined => {
-    let artistClusterMethod: ArtistClusterMode;
-    if (graph === 'similarArtists') {
-      artistClusterMethod = similarArtistClusterMethod;
-    } else if (graph === 'artists' && collectionMode) {
-      artistClusterMethod = collectionArtistClusterMethod;
-    } else {
-      artistClusterMethod = exploreArtistClusterMethod;
-    }
-    if (!artistClusters || !['genre', 'popularity'].includes(artistClusterMethod) || !showClusterOverlay) return undefined;
-    const overlays: ClusterOverlay[] = [];
-    for (const cluster of artistClusters.clusters.values()) {
-      if (cluster.artistIds.length === 0) continue;
-      overlays.push({
-        id: cluster.id,
-        name: cluster.name,
-        color: cluster.color,
-        nodeIds: new Set(cluster.artistIds),
-      });
-    }
-    return overlays.length > 0 ? overlays : undefined;
-  }, [artistClusters, graph, collectionMode, collectionArtistClusterMethod, exploreArtistClusterMethod, similarArtistClusterMethod, showClusterOverlay]);
 
   // Compute radial layout from cluster tier data for popularity stratification
   const artistRadialLayout = useMemo(() => {
@@ -2532,6 +2371,7 @@ function App() {
 
   const onDecadeSelectionChange = (selectedIDs: string[]) => {
     setSelectedDecades(selectedIDs);
+    // TODO: Implement decade filtering logic
   }
 
   // Generic collection filter handler - works for any filter type
@@ -2949,10 +2789,12 @@ function App() {
                       selectedGenreIds={collectionFilters.genres}
                       genreColorMap={genreColorMap}
                     />
+                    {/* TODO: Add DecadesFilter when ready
                     <DecadesFilter
                       onDecadeSelectionChange={(ids) => onCollectionFilterChange('decades', ids)}
                       selectedDecadeIds={collectionFilters.decades}
                     />
+                    */}
                   </motion.div>
                 )}
               </AnimatePresence>
@@ -3047,7 +2889,6 @@ function App() {
                   disableDimming={isUserDraggingArtistCanvas || isArtistDrawerAtMinSnap}
                   radialLayout={artistRadialLayout}
                   priorityLabelIds={centralArtistLabelIds}
-                  clusterOverlays={artistClusterOverlays}
                 />
 
           {/* Genre hover preview */}
@@ -3155,22 +2996,14 @@ function App() {
               {(graph === 'genres' || graph === 'artists' || graph === 'similarArtists') && (
                 <ClusteringPanel
                   graphType={graph === 'genres' ? 'genres' : 'artists'}
-                  clusterMode={graph === 'genres' ? genreClusterMode[0] : (graph === 'similarArtists' ? similarArtistClusterMethod : (collectionMode ? collectionArtistClusterMethod : exploreArtistClusterMethod))}
+                  clusterMode={graph === 'genres' ? genreClusterMode[0] : artistClusterMethod}
                   setClusterMode={(mode) => {
                     if (graph === 'genres') {
                       onGenreClusterModeChange(mode as GenreClusterMode[]);
                     } else {
                       const newMethod = (Array.isArray(mode) ? mode[0] : mode) as ArtistClusterMode;
-                      if (graph === 'similarArtists') {
-                        setSimilarArtistClusterMethod(newMethod);
-                        localStorage.setItem('similarArtistClusterMethod', newMethod);
-                      } else if (collectionMode) {
-                        setCollectionArtistClusterMethod(newMethod);
-                        localStorage.setItem('collectionArtistClusterMethod', newMethod);
-                      } else {
-                        setExploreArtistClusterMethod(newMethod);
-                        localStorage.setItem('exploreArtistClusterMethod', newMethod);
-                      }
+                      setArtistClusterMethod(newMethod);
+                      localStorage.setItem('artistClusterMethod', newMethod);
                     }
                   }}
                   dagMode={dagMode}
@@ -3183,12 +3016,6 @@ function App() {
                   genreColorLegend={genreColorLegend}
                   artistClusters={(graph === 'artists' || graph === 'similarArtists') ? artistClusters : undefined}
                   clusteringInProgress={(graph === 'artists' || graph === 'similarArtists') ? clusteringInProgress : undefined}
-                  collectionMode={collectionMode}
-                  showClusterOverlay={showClusterOverlay}
-                  setShowClusterOverlay={(v) => {
-                    setShowClusterOverlay(v);
-                    localStorage.setItem('showClusterOverlay', String(v));
-                  }}
                 />
               )}
               <DisplayPanel

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -170,6 +170,7 @@ function App() {
   const [pendingArtistGenreGraph, setPendingArtistGenreGraph] = useState<Artist | undefined>(undefined);
   const [genreTopArtistsCache, setGenreTopArtistsCache] = useState<Map<string, Artist[]>>(new Map());
   const artistImageCache = useRef<Map<string, string>>(new Map());
+  const [prefetchedImageCache, setPrefetchedImageCache] = useState<Map<string, string>>(new Map());
   const artistObjectCache = useRef<Map<string, Artist>>(new Map());
   const [canCreateSimilarArtistGraph, setCanCreateSimilarArtistGraph] = useState<boolean>(false);
   const [genreClusterMode, setGenreClusterMode] = useState<GenreClusterMode[]>(DEFAULT_CLUSTER_MODE);
@@ -299,6 +300,7 @@ function App() {
     fetchArtistBySearch,
     similarArtists,
     fetchSimilarArtists,
+    prefetchSimilarImages,
   } = useArtists(artistQueryGenreIDs, TOP_ARTISTS_TO_FETCH, artistNodeLimitType, artistNodeCount, isBeforeArtistLoad, collectionMode);
 
   // Fetch top artists for the currently displayed genre info or the active filter
@@ -1606,8 +1608,34 @@ function App() {
     }
   }, [selectedArtist]);
 
+  useEffect(() => {
+    if (!selectedArtist?.id || !selectedArtist.similar?.length) return;
+    const uncached = selectedArtist.similar.filter((name) => !artistImageCache.current.has(name));
+    if (!uncached.length) return;
+    prefetchSimilarImages(selectedArtist).then((artists) => {
+      console.log('[prefetch] returned names:', artists.map(a => a.name));
+      console.log('[prefetch] similar string names:', selectedArtist.similar);
+      const newEntries: [string, string][] = [];
+      for (const a of artists) {
+        if (a.name && a.image) {
+          artistImageCache.current.set(a.name, a.image as string);
+          newEntries.push([a.name, a.image as string]);
+        }
+      }
+      console.log('[prefetch] newEntries cached:', newEntries.map(([n]) => n));
+      if (newEntries.length) {
+        setPrefetchedImageCache((prev) => {
+          const next = new Map(prev);
+          for (const [name, img] of newEntries) next.set(name, img);
+          return next;
+        });
+      }
+    });
+  }, [selectedArtist?.id]);
+
   const getArtistImageByName = (name: string) => {
     const raw = artistImageCache.current.get(name)
+      ?? prefetchedImageCache.get(name)
       ?? currentArtists.find((x) => x.name === name)?.image as string | undefined;
     return raw ? fixWikiImageURL(raw) : undefined;
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -301,6 +301,7 @@ function App() {
     similarArtists,
     fetchSimilarArtists,
     prefetchSimilarImages,
+    fetchArtistByName,
   } = useArtists(artistQueryGenreIDs, TOP_ARTISTS_TO_FETCH, artistNodeLimitType, artistNodeCount, isBeforeArtistLoad, collectionMode);
 
   // Fetch top artists for the currently displayed genre info or the active filter
@@ -1558,13 +1559,14 @@ function App() {
     if (artist) {
       onArtistNodeClick(artist);
     } else {
-      const fetched = await fetchArtistBySearch(name);
-      if (fetched) {
-        setSelectedArtist(undefined);
-        setArtistInfoToShow(fetched);
-        setShowArtistCard(true);
-        addRecentSelection(fetched);
-        updateUrl({ type: 'artist', id: fetched.id, name: fetched.name });
+      const cachedArtist = artistObjectCache.current.get(name);
+      if (cachedArtist) {
+        onArtistNodeClick(cachedArtist);
+      } else {
+        const fetched = await fetchArtistByName(name);
+        if (fetched) {
+          onArtistNodeClick(fetched);
+        }
       }
     }
   }

--- a/src/components/ArtistAvatar.tsx
+++ b/src/components/ArtistAvatar.tsx
@@ -59,12 +59,12 @@ export function ArtistAvatar({
 
       {/* Out-of-view: ArrowUp icon colored with genre color */}
       {isInView === false && (
-        <span className="absolute bottom-0 -right-1 size-5 rounded-full bg-accent flex items-center justify-center">
+        <span className="absolute bottom-0 -right-1 size-5 rounded-sm bg-accent flex items-center justify-center">
           <ChevronRight className="size-4" style={{ color: color }} />
         </span>
       )}
 
-      {/* In-graph: neutral GitFork badge — TODO: swap GitFork for the right icon */}
+      {/* In-graph: colored circle */}
       {isInView === true && (
         <span className="absolute bottom-0 -right-1 size-5 rounded-sm bg-accent flex items-center justify-center">
           <span

--- a/src/components/ArtistAvatar.tsx
+++ b/src/components/ArtistAvatar.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@/lib/utils';
-import { ArrowUp, GitFork } from 'lucide-react';
+import { ArrowUp, GitFork, ChevronRight } from 'lucide-react';
 
 interface ArtistAvatarProps {
   name: string;
@@ -35,10 +35,9 @@ export function ArtistAvatar({
     <span
       aria-hidden="true"
       className={cn(
-        'relative inline-flex size-5 items-center justify-center rounded-xl border',
+        'relative inline-flex size-12 items-center justify-center rounded-full border',
         className,
       )}
-      style={{ borderColor: color }}
     >
       {imageUrl ? (
         <img
@@ -58,20 +57,21 @@ export function ArtistAvatar({
         </span>
       )}
 
-      {/* Out-of-view: ArrowUp badge colored with genre color */}
+      {/* Out-of-view: ArrowUp icon colored with genre color */}
       {isInView === false && (
-        <span
-          className="absolute -bottom-0 -right-1 rounded-full p-1 flex items-center justify-center"
-          style={{ backgroundColor: color ?? 'hsl(var(--accent))' }}
-        >
-          <ArrowUp className="size-4 text-white" />
+        <span className="absolute bottom-0 -right-1 size-5 rounded-full bg-accent flex items-center justify-center">
+          <ChevronRight className="size-4" style={{ color: color }} />
         </span>
       )}
 
       {/* In-graph: neutral GitFork badge — TODO: swap GitFork for the right icon */}
       {isInView === true && (
-        <span className="absolute -bottom-0 -right-1 rounded-full bg-accent p-1 flex items-center justify-center">
-          <GitFork className="size-4 text-muted-foreground" />
+        <span className="absolute bottom-0 -right-1 size-5 rounded-sm bg-accent flex items-center justify-center">
+          <span
+            aria-hidden="true"
+            className="size-2.5 rounded-full"
+            style={{ backgroundColor: color ?? '#ffffff' }}
+          />
         </span>
       )}
     </span>

--- a/src/components/ArtistAvatar.tsx
+++ b/src/components/ArtistAvatar.tsx
@@ -1,0 +1,81 @@
+import { cn } from '@/lib/utils';
+import { ArrowUp, GitFork } from 'lucide-react';
+
+interface ArtistAvatarProps {
+  name: string;
+  imageUrl?: string;
+  /** Genre color — used as border tint and out-of-view badge color */
+  color?: string;
+  /**
+   * Whether the artist is currently visible in the graph.
+   * - `true`  → in-graph icon (GitFork placeholder)
+   * - `false` → out-of-view icon (ArrowUp, colored with `color`)
+   * - `undefined` → no icon badge
+   */
+  isInView?: boolean;
+  className?: string;
+  labelClassName?: string;
+}
+
+/**
+ * Artist avatar circle with an optional state-driven icon badge.
+ * Used in GenreInfo (top artists) and ArtistInfo (similar artists).
+ */
+export function ArtistAvatar({
+  name,
+  imageUrl,
+  color,
+  isInView,
+  className,
+  labelClassName,
+}: ArtistAvatarProps) {
+  const initial = name?.[0]?.toUpperCase() ?? '?';
+
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        'relative inline-flex size-5 items-center justify-center rounded-xl border',
+        className,
+      )}
+      style={{ borderColor: color }}
+    >
+      {imageUrl ? (
+        <img
+          src={imageUrl}
+          alt={`${name} avatar`}
+          className="h-full w-full rounded-full object-cover"
+          loading="lazy"
+        />
+      ) : (
+        <span
+          className={cn(
+            'h-full w-full rounded-full bg-muted flex items-center justify-center text-[10px]',
+            labelClassName,
+          )}
+        >
+          {initial}
+        </span>
+      )}
+
+      {/* Out-of-view: ArrowUp badge colored with genre color */}
+      {isInView === false && (
+        <span
+          className="absolute -bottom-0 -right-1 rounded-full p-1 flex items-center justify-center"
+          style={{ backgroundColor: color ?? 'hsl(var(--accent))' }}
+        >
+          <ArrowUp className="size-4 text-white" />
+        </span>
+      )}
+
+      {/* In-graph: neutral GitFork badge — TODO: swap GitFork for the right icon */}
+      {isInView === true && (
+        <span className="absolute -bottom-0 -right-1 rounded-full bg-accent p-1 flex items-center justify-center">
+          <GitFork className="size-4 text-muted-foreground" />
+        </span>
+      )}
+    </span>
+  );
+}
+
+export default ArtistAvatar;

--- a/src/components/ArtistAvatar.tsx
+++ b/src/components/ArtistAvatar.tsx
@@ -35,7 +35,7 @@ export function ArtistAvatar({
     <span
       aria-hidden="true"
       className={cn(
-        'relative inline-flex size-12 items-center justify-center rounded-full border',
+        'relative inline-flex size-12 items-center justify-center rounded-full active:scale-95 transition-transform border ring-2 ring-transparent group-hover:ring-primary/30',
         className,
       )}
     >
@@ -43,7 +43,7 @@ export function ArtistAvatar({
         <img
           src={imageUrl}
           alt={`${name} avatar`}
-          className="h-full w-full rounded-full object-cover"
+          className="h-full w-full rounded-full object-cover "
           loading="lazy"
         />
       ) : (

--- a/src/components/ArtistInfo.tsx
+++ b/src/components/ArtistInfo.tsx
@@ -504,7 +504,14 @@ export function ArtistInfo({
                         return (
                           <button
                             key={name}
-                            onClick={() => setArtistFromName(name)}
+                            onClick={() => {
+                            const artist = getArtistByName?.(name);
+                            if (artist && onViewSimilarArtistGraph) {
+                              onViewSimilarArtistGraph(artist);
+                            } else {
+                              setArtistFromName(name);
+                            }
+                          }}
                             title={isInView ? `Go to ${name}` : `View ${name}`}
                             className="flex flex-col items-center gap-2 flex-none w-auto group"
                           >

--- a/src/components/ArtistInfo.tsx
+++ b/src/components/ArtistInfo.tsx
@@ -494,7 +494,7 @@ export function ArtistInfo({
                     ) : (
                       <span className="text-md font-semibold">Similar Artists</span>
                     )}
-                    <div className="flex gap-3 overflow-x-auto no-scrollbar pb-1 -mx-1 px-1">
+                    <div className="grid grid-cols-4 gap-4 w-full pb-1 -mx-1 px-1">
                       {similarFilter(selectedArtist.similar).map((name) => {
                         const artistObj = getArtistByName?.(name);
                         const isInView = !!artistObj;
@@ -506,7 +506,7 @@ export function ArtistInfo({
                             key={name}
                             onClick={() => setArtistFromName(name)}
                             title={isInView ? `Go to ${name}` : `View ${name}`}
-                            className="flex flex-col items-center gap-2 flex-none w-[68px] group"
+                            className="flex flex-col items-center gap-2 flex-none w-auto group"
                           >
                             <BadgeIndicator
                               type="artist"
@@ -514,10 +514,10 @@ export function ArtistInfo({
                               imageUrl={img}
                               color={genreColor}
                               icon={!isInView ? EyeOff : undefined}
-                              className="size-[52px] ring-2 ring-transparent group-hover:ring-primary/30 group-hover:scale-105 transition-all duration-200"
+                              className="size-[64px] border-2 ring-2 ring-transparent group-hover:ring-primary/30 group-hover:scale-105 transition-all duration-200"
                               labelClassName="text-base"
                             />
-                            <span className="text-[11px] leading-tight text-center line-clamp-2 w-full font-medium text-foreground/80 group-hover:text-foreground transition-colors">
+                            <span className="text-[11px] leading-tight text-center line-clamp-2 w-full font-semibold group-hover:text-foreground transition-colors">
                               {name}
                             </span>
                           </button>

--- a/src/components/ArtistInfo.tsx
+++ b/src/components/ArtistInfo.tsx
@@ -521,7 +521,7 @@ export function ArtistInfo({
                               imageUrl={img}
                               color={genreColor}
                               icon={!isInView ? EyeOff : undefined}
-                              className="size-[64px] border-2 ring-2 ring-transparent group-hover:ring-primary/30 group-hover:scale-105 transition-all duration-200"
+                              className="size-[64px] border-2  group-active:scale-95 transition-all duration-200"
                               labelClassName="text-base"
                             />
                             <span className="text-[11px] leading-tight text-center line-clamp-2 w-full font-semibold group-hover:text-foreground transition-colors">

--- a/src/components/ArtistInfo.tsx
+++ b/src/components/ArtistInfo.tsx
@@ -37,6 +37,7 @@ interface ArtistInfoProps {
   onGenreClick?: (name: string) => void;
   getArtistImageByName?: (name: string) => string | undefined;
   getArtistByName?: (name: string) => Artist | undefined;
+  getArtistColorByName?: (name: string) => string | undefined;
   genreColorMap?: Map<string, string>;
   getArtistColor: (artist: Artist) => string;
   getGenreNameById?: (id: string) => string | undefined;
@@ -70,6 +71,7 @@ export function ArtistInfo({
   onGenreClick,
   getArtistImageByName,
   getArtistByName,
+  getArtistColorByName,
   genreColorMap,
   getArtistColor,
   getGenreNameById,
@@ -499,7 +501,9 @@ export function ArtistInfo({
                         const artistObj = getArtistByName?.(name);
                         const isInView = !!artistObj;
                         const img = getArtistImageByName?.(name);
-                        const genreColor = artistObj ? getArtistColor(artistObj) : undefined;
+                        const genreColor = artistObj
+                          ? getArtistColor(artistObj)
+                          : getArtistColorByName?.(name);
 
                         return (
                           <button

--- a/src/components/ArtistInfo.tsx
+++ b/src/components/ArtistInfo.tsx
@@ -5,7 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { ResponsiveDrawer } from "@/components/ResponsiveDrawer";
 import { fixWikiImageURL, formatDate, formatNumber } from "@/lib/utils";
-import { CirclePlay, SquarePlus, Ellipsis, Info, Flag, Loader2, ChevronRight, ChevronDown, EyeOff, Disc3 } from "lucide-react";
+import { CirclePlay, SquarePlus, Ellipsis, Info, Flag, Loader2, ChevronRight, ChevronDown, Disc3} from "lucide-react";
 import { toast } from "sonner";
 import {
   DropdownMenu,
@@ -19,7 +19,7 @@ import { SplitButton, SplitButtonAction, SplitButtonTrigger } from "@/components
 import ReportIncorrectInfoDialog from "@/components/ReportIncorrectInfoDialog";
 import { Alert, AlertDescription } from "./ui/alert";
 import GenreBadge from "@/components/GenreBadge";
-import { BadgeIndicator } from "@/components/BadgeIndicator";
+import ArtistAvatar from "@/components/ArtistAvatar";
 import { AddButton } from "./AddButton";
 import { Separator } from "@radix-ui/react-separator";
 import { ImageLightbox } from "@/components/ImageLightbox";
@@ -515,13 +515,12 @@ export function ArtistInfo({
                             title={isInView ? `Go to ${name}` : `View ${name}`}
                             className="flex flex-col items-center gap-2 flex-none w-auto group"
                           >
-                            <BadgeIndicator
-                              type="artist"
+                            <ArtistAvatar
                               name={name}
                               imageUrl={img}
                               color={genreColor}
-                              icon={!isInView ? EyeOff : undefined}
-                              className="size-[64px] border-2  group-active:scale-95 transition-all duration-200"
+                              isInView={isInView}
+                              className="size-[64px] border-2 group-active:scale-95 transition-all duration-200"
                               labelClassName="text-base"
                             />
                             <span className="text-[11px] leading-tight text-center line-clamp-2 w-full font-semibold group-hover:text-foreground transition-colors">

--- a/src/components/ArtistInfo.tsx
+++ b/src/components/ArtistInfo.tsx
@@ -498,7 +498,7 @@ export function ArtistInfo({
                       {similarFilter(selectedArtist.similar).map((name) => {
                         const artistObj = getArtistByName?.(name);
                         const isInView = !!artistObj;
-                        const img = isInView ? getArtistImageByName?.(name) : undefined;
+                        const img = getArtistImageByName?.(name);
                         const genreColor = artistObj ? getArtistColor(artistObj) : undefined;
 
                         return (

--- a/src/components/ArtistInfo.tsx
+++ b/src/components/ArtistInfo.tsx
@@ -18,8 +18,8 @@ import {
 import { SplitButton, SplitButtonAction, SplitButtonTrigger } from "@/components/ui/split-button"
 import ReportIncorrectInfoDialog from "@/components/ReportIncorrectInfoDialog";
 import { Alert, AlertDescription } from "./ui/alert";
-import ArtistBadge from "@/components/ArtistBadge";
 import GenreBadge from "@/components/GenreBadge";
+import { BadgeIndicator } from "@/components/BadgeIndicator";
 import { AddButton } from "./AddButton";
 import { Separator } from "@radix-ui/react-separator";
 import { ImageLightbox } from "@/components/ImageLightbox";
@@ -481,7 +481,7 @@ export function ArtistInfo({
 
                 {/* Similar Artists */}
                 {selectedArtist?.similar && similarFilter(selectedArtist.similar).length > 0 && (
-                  <div className="flex flex-col gap-2">
+                  <div className="flex flex-col gap-3">
                     {onViewSimilarArtistGraph && selectedArtist ? (
                       <button
                         className="hover:opacity-70 transition-opacity cursor-pointer text-left inline-flex items-center flex-wrap"
@@ -489,28 +489,38 @@ export function ArtistInfo({
                         title={`Explore artists similar to ${selectedArtist.name}`}
                       >
                         <span className="text-md font-semibold">Similar Artists</span>
-                        <ChevronRight className="shrink-0 text-muted-foreground size-5"/>
+                        <ChevronRight className="shrink-0 text-muted-foreground size-5" />
                       </button>
                     ) : (
                       <span className="text-md font-semibold">Similar Artists</span>
                     )}
-                    <div className="flex flex-wrap items-center gap-1.5">
+                    <div className="flex gap-3 overflow-x-auto no-scrollbar pb-1 -mx-1 px-1">
                       {similarFilter(selectedArtist.similar).map((name) => {
                         const artistObj = getArtistByName?.(name);
                         const isInView = !!artistObj;
-                        const img = getArtistImageByName?.(name);
+                        const img = isInView ? getArtistImageByName?.(name) : undefined;
                         const genreColor = artistObj ? getArtistColor(artistObj) : undefined;
 
                         return (
-                          <ArtistBadge
+                          <button
                             key={name}
-                            name={name}
-                            imageUrl={isInView ? img : undefined}
-                            genreColor={genreColor}
                             onClick={() => setArtistFromName(name)}
                             title={isInView ? `Go to ${name}` : `View ${name}`}
-                            icon={!isInView ? EyeOff : undefined}
-                          />
+                            className="flex flex-col items-center gap-2 flex-none w-[68px] group"
+                          >
+                            <BadgeIndicator
+                              type="artist"
+                              name={name}
+                              imageUrl={img}
+                              color={genreColor}
+                              icon={!isInView ? EyeOff : undefined}
+                              className="size-[52px] ring-2 ring-transparent group-hover:ring-primary/30 group-hover:scale-105 transition-all duration-200"
+                              labelClassName="text-base"
+                            />
+                            <span className="text-[11px] leading-tight text-center line-clamp-2 w-full font-medium text-foreground/80 group-hover:text-foreground transition-colors">
+                              {name}
+                            </span>
+                          </button>
                         );
                       })}
                     </div>

--- a/src/components/ArtistInfo.tsx
+++ b/src/components/ArtistInfo.tsx
@@ -502,20 +502,13 @@ export function ArtistInfo({
                         const genreColor = artistObj ? getArtistColor(artistObj) : undefined;
 
                         return (
-                          // TODO: Provide navigation options for artists not in view
                           <ArtistBadge
                             key={name}
                             name={name}
                             imageUrl={isInView ? img : undefined}
                             genreColor={genreColor}
-                            onClick={() => {
-                              if (isInView) {
-                                setArtistFromName(name);
-                              } else {
-                                toast.info(`${name} is not in the current view.`);
-                              }
-                            }}
-                            title={!isInView ? `${name} is not in the current view` : `Go to ${name}`}
+                            onClick={() => setArtistFromName(name)}
+                            title={isInView ? `Go to ${name}` : `View ${name}`}
                             icon={!isInView ? EyeOff : undefined}
                           />
                         );

--- a/src/components/ArtistInfo.tsx
+++ b/src/components/ArtistInfo.tsx
@@ -518,7 +518,7 @@ export function ArtistInfo({
                               imageUrl={img}
                               color={genreColor}
                               isInView={isInView || undefined}
-                              className="size-[64px] border-2 group-active:scale-95 transition-all duration-200"
+                              className="size-[64px] border-2 transition-all duration-200"
                               labelClassName="text-base"
                             />
                             <span className="text-[11px] leading-tight text-center line-clamp-2 w-full font-semibold group-hover:text-foreground transition-colors">

--- a/src/components/ArtistInfo.tsx
+++ b/src/components/ArtistInfo.tsx
@@ -534,20 +534,20 @@ export function ArtistInfo({
                 {/* Genres */}
                 {selectedArtist?.genres && selectedArtist.genres.length > 0 && (
                   <div className="flex flex-col gap-2">
-                    {onViewArtistGraph && selectedArtist ? (
-                      <button
-                        className="hover:opacity-70 transition-opacity cursor-pointer text-left inline-flex items-center flex-wrap"
-                        onClick={() => onViewArtistGraph(selectedArtist)}
-                        type="button"
-                        disabled={viewRelatedArtistsLoading}
-                        title={`Explore Related Genres for ${selectedArtist.name}`}
-                      >
-                        <span className="text-md font-semibold">Explore Related Genres</span>
-                        <ChevronRight className="shrink-0 text-muted-foreground size-5" />
-                      </button>
-                    ) : (
+                    <div className="flex items-center justify-between">
                       <span className="text-md font-semibold">Genres</span>
-                    )}
+                      {onViewArtistGraph && selectedArtist && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => onViewArtistGraph(selectedArtist)}
+                          disabled={viewRelatedArtistsLoading}
+                          title={`Explore related genres for ${selectedArtist.name}`}
+                        >
+                          Graph <ChevronRight className="size-4" />
+                        </Button>
+                      )}
+                    </div>
                     <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
                       {selectedArtist.genres.map((genreId) => {
                         const name = getGenreNameById?.(genreId) ?? genreId;

--- a/src/components/ArtistInfo.tsx
+++ b/src/components/ArtistInfo.tsx
@@ -493,7 +493,7 @@ export function ArtistInfo({
                           onClick={() => onViewSimilarArtistGraph(selectedArtist)}
                           title={`Explore artists similar to ${selectedArtist.name}`}
                         >
-                          View Graph <ChevronRight className="size-4" />
+                          Graph <ChevronRight className="size-4" />
                         </Button>
                       )}
                     </div>

--- a/src/components/ArtistInfo.tsx
+++ b/src/components/ArtistInfo.tsx
@@ -500,6 +500,7 @@ export function ArtistInfo({
                     <div className="grid grid-cols-4 gap-4 w-full pb-1 -mx-1 px-1">
                       {similarFilter(selectedArtist.similar).map((name) => {
                         const artistObj = getArtistByName?.(name);
+                        const isInView = !!artistObj;
                         const img = getArtistImageByName?.(name);
                         const genreColor = artistObj
                           ? getArtistColor(artistObj)
@@ -516,6 +517,7 @@ export function ArtistInfo({
                               name={name}
                               imageUrl={img}
                               color={genreColor}
+                              isInView={isInView || undefined}
                               className="size-[64px] border-2 group-active:scale-95 transition-all duration-200"
                               labelClassName="text-base"
                             />

--- a/src/components/ArtistInfo.tsx
+++ b/src/components/ArtistInfo.tsx
@@ -484,22 +484,22 @@ export function ArtistInfo({
                 {/* Similar Artists */}
                 {selectedArtist?.similar && similarFilter(selectedArtist.similar).length > 0 && (
                   <div className="flex flex-col gap-3">
-                    {onViewSimilarArtistGraph && selectedArtist ? (
-                      <button
-                        className="hover:opacity-70 transition-opacity cursor-pointer text-left inline-flex items-center flex-wrap"
-                        onClick={() => onViewSimilarArtistGraph(selectedArtist)}
-                        title={`Explore artists similar to ${selectedArtist.name}`}
-                      >
-                        <span className="text-md font-semibold">Similar Artists</span>
-                        <ChevronRight className="shrink-0 text-muted-foreground size-5" />
-                      </button>
-                    ) : (
+                    <div className="flex items-center justify-between">
                       <span className="text-md font-semibold">Similar Artists</span>
-                    )}
+                      {onViewSimilarArtistGraph && selectedArtist && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => onViewSimilarArtistGraph(selectedArtist)}
+                          title={`Explore artists similar to ${selectedArtist.name}`}
+                        >
+                          View Graph <ChevronRight className="size-4" />
+                        </Button>
+                      )}
+                    </div>
                     <div className="grid grid-cols-4 gap-4 w-full pb-1 -mx-1 px-1">
                       {similarFilter(selectedArtist.similar).map((name) => {
                         const artistObj = getArtistByName?.(name);
-                        const isInView = !!artistObj;
                         const img = getArtistImageByName?.(name);
                         const genreColor = artistObj
                           ? getArtistColor(artistObj)
@@ -508,22 +508,14 @@ export function ArtistInfo({
                         return (
                           <button
                             key={name}
-                            onClick={() => {
-                            const artist = getArtistByName?.(name);
-                            if (artist && onViewSimilarArtistGraph) {
-                              onViewSimilarArtistGraph(artist);
-                            } else {
-                              setArtistFromName(name);
-                            }
-                          }}
-                            title={isInView ? `Go to ${name}` : `View ${name}`}
+                            onClick={() => setArtistFromName(name)}
+                            title={`View ${name}`}
                             className="flex flex-col items-center gap-2 flex-none w-auto group"
                           >
                             <ArtistAvatar
                               name={name}
                               imageUrl={img}
                               color={genreColor}
-                              isInView={isInView}
                               className="size-[64px] border-2 group-active:scale-95 transition-all duration-200"
                               labelClassName="text-base"
                             />

--- a/src/components/ArtistsForceGraph.tsx
+++ b/src/components/ArtistsForceGraph.tsx
@@ -2,7 +2,6 @@ import { forwardRef, memo, useMemo } from "react";
 import Graph, {
   type GraphHandle,
   type SharedGraphNode,
-  type ClusterOverlay,
 } from "./Graph";
 import { calculateNodeRadius, DEFAULT_MIN_RADIUS, DEFAULT_MAX_RADIUS } from "./Graph/graphStyle";
 import { Artist, NodeLink } from "@/types";
@@ -38,7 +37,6 @@ interface ArtistsForceGraphProps {
     nodeToRadius: Map<string, number>;
     strength?: number;
   };
-  clusterOverlays?: ClusterOverlay[];
 }
 
 
@@ -69,7 +67,6 @@ const ArtistsForceGraph = forwardRef<GraphHandle, ArtistsForceGraphProps>(
       disableDimming,
       priorityLabelIds,
       radialLayout,
-      clusterOverlays,
     },
     ref,
   ) => {
@@ -143,7 +140,6 @@ const ArtistsForceGraph = forwardRef<GraphHandle, ArtistsForceGraphProps>(
         disableDimming={disableDimming}
         priorityLabelIds={priorityLabelIds}
         radialLayout={radialLayout}
-        clusterOverlays={clusterOverlays}
       />
     );
   },

--- a/src/components/BadgeIndicator.tsx
+++ b/src/components/BadgeIndicator.tsx
@@ -9,6 +9,7 @@ interface BadgeIndicatorProps {
   color?: string;
   imageUrl?: string;
   className?: string;
+  labelClassName?: string;
   icon?: LucideIcon;
 }
 
@@ -21,6 +22,7 @@ export function BadgeIndicator({
   color,
   imageUrl,
   className,
+  labelClassName,
   icon: Icon,
 }: BadgeIndicatorProps) {
   if (type === 'genre') {
@@ -54,7 +56,7 @@ export function BadgeIndicator({
           loading="lazy"
         />
       ) : (
-        <span className="h-full w-full rounded-full bg-muted text-center text-[10px] leading-5">
+        <span className={cn("h-full w-full rounded-full bg-muted flex items-center justify-center text-[10px]", labelClassName)}>
           {initial}
         </span>
       )}

--- a/src/components/BadgeIndicator.tsx
+++ b/src/components/BadgeIndicator.tsx
@@ -41,14 +41,12 @@ export function BadgeIndicator({
     <span
       aria-hidden="true"
       className={cn(
-        'inline-flex size-5 items-center justify-center rounded-full border',
+        'relative inline-flex size-5 items-center justify-center rounded-full border',
         className,
       )}
       style={{ borderColor: color }}
     >
-      {Icon ? (
-        <Icon className="size-3 text-muted-foreground" />
-      ) : imageUrl ? (
+      {imageUrl ? (
         <img
           src={imageUrl}
           alt={`${name} avatar`}
@@ -58,6 +56,11 @@ export function BadgeIndicator({
       ) : (
         <span className={cn("h-full w-full rounded-full bg-muted flex items-center justify-center text-[10px]", labelClassName)}>
           {initial}
+        </span>
+      )}
+      {Icon && (
+        <span className="absolute -bottom-0 -right-1 rounded-full bg-accent p-1 flex items-center justify-center">
+          <Icon className="size-4 text-muted-foreground" />
         </span>
       )}
     </span>

--- a/src/components/BadgeIndicator.tsx
+++ b/src/components/BadgeIndicator.tsx
@@ -41,7 +41,7 @@ export function BadgeIndicator({
     <span
       aria-hidden="true"
       className={cn(
-        'relative inline-flex size-5 items-center justify-center rounded-full border',
+        'relative inline-flex size-5 items-center justify-center rounded-xl border',
         className,
       )}
       style={{ borderColor: color }}

--- a/src/components/ClusteringPanel.tsx
+++ b/src/components/ClusteringPanel.tsx
@@ -17,25 +17,19 @@ interface ClusteringPanelProps {
     genreColorLegend?: { id: string; name: string; color: string; isBlended?: boolean; artistCount?: number }[];
     artistClusters?: ClusterResult | null;
     clusteringInProgress?: boolean;
-    collectionMode?: boolean;
-    showClusterOverlay?: boolean;
-    setShowClusterOverlay?: (v: boolean) => void;
 }
 
-export default function ClusteringPanel({
-    graphType,
-    clusterMode,
-    setClusterMode,
-    dagMode,
+export default function ClusteringPanel({ 
+    graphType, 
+    clusterMode, 
+    setClusterMode, 
+    dagMode, 
     setDagMode,
     artistColorMode,
     setArtistColorMode,
     genreColorLegend,
     artistClusters,
-    clusteringInProgress,
-    collectionMode,
-    showClusterOverlay,
-    setShowClusterOverlay,
+    clusteringInProgress
 }: ClusteringPanelProps) {
 
     const genreOptions = [
@@ -46,24 +40,13 @@ export default function ClusteringPanel({
 
     const artistOptions = [
         { id: "similarArtists", label: "Similar Artists", description: "Uses the existing artist network structure to find communities. Artists connected by similar artist links form clusters." },
+        // { id: "hybrid", label: "Hybrid", description: "Combines vector-based similarity with the artist network to form more robust communities." },
         { id: "popularity", label: "Popularity", description: "Arranges artists in concentric rings by listener count. Popular artists at center, underground at outer ring." },
-        ...(collectionMode ? [
-            {
-                id: "genre",
-                label: "By Genre",
-                description: "Groups your liked artists into clusters by their primary genre — Rock, Electronic, Hip-Hop, and so on. Same-genre artists are physically pulled together.",
-            },
-            {
-                id: "byTags",
-                label: "By Tags",
-                description: "Combines tag-based similarity with your artist network structure to find communities. Blends musical similarity with direct connections.",
-            },
-        ] : []),
     ];
 
     const options = graphType === 'genres' ? genreOptions : artistOptions;
 
-    const feildsetStyles = "rounded-2xl bg-accent dark:bg-accent/50 border border-accent"
+    const feildsetStyles = "rounded-2xl bg-accent dark:bg-accent/50 border border-muted"
 
     return (
         <ResponsivePanel
@@ -132,15 +115,6 @@ export default function ClusteringPanel({
                         </motion.div>
                     ))}
                 </RadioGroup>
-                {graphType === 'artists' && ['genre', 'byTags', 'popularity'].includes(clusterMode) && setShowClusterOverlay && (
-                    <div className={`${feildsetStyles} flex items-center justify-between w-full p-3`}>
-                        <div className="flex flex-col">
-                            <span className="text-md font-semibold leading-none text-gray-900 dark:text-gray-100">Show cluster overlay</span>
-                            <span className="text-sm text-muted-foreground mt-1">Draw cluster region hulls on the graph.</span>
-                        </div>
-                        <Switch checked={showClusterOverlay ?? false} onCheckedChange={setShowClusterOverlay} />
-                    </div>
-                )}
                 {graphType === 'artists' && artistColorMode !== undefined && setArtistColorMode && (
                     <>
                         <div className={`${feildsetStyles} flex items-center justify-between w-full p-3 pt-3`}>

--- a/src/components/DecadesFilter.tsx
+++ b/src/components/DecadesFilter.tsx
@@ -12,6 +12,7 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
+import { toast } from "sonner";
 
 // Dummy data: decades from 1930s to 2020s
 const DECADES = [
@@ -29,22 +30,13 @@ const DECADES = [
 
 interface DecadesFilterProps {
   onDecadeSelectionChange: (selectedIds: string[]) => void;
-  selectedDecadeIds?: string[];
 }
 
 export default function DecadesFilter({
   onDecadeSelectionChange,
-  selectedDecadeIds,
 }: DecadesFilterProps) {
-  const [selectedDecades, setSelectedDecades] = useState<Set<string>>(
-    new Set(selectedDecadeIds ?? [])
-  );
-
-  useEffect(() => {
-    if (selectedDecadeIds !== undefined) {
-      setSelectedDecades(new Set(selectedDecadeIds));
-    }
-  }, [selectedDecadeIds]);
+  // Track selected decades using a Set
+  const [selectedDecades, setSelectedDecades] = useState<Set<string>>(new Set());
   const [query, setQuery] = useState("");
 
   // Get selected decades as array for display
@@ -53,22 +45,28 @@ export default function DecadesFilter({
     [selectedDecades]
   );
 
+  // Notify parent component when selection changes
+  useEffect(() => {
+    const ids = selectedDecadesArray.map(d => d.id);
+    onDecadeSelectionChange(ids);
+  }, [selectedDecadesArray]);
+
   // Toggle a decade selection
   const toggleDecade = (decadeId: string) => {
-    const next = new Set(selectedDecades);
-    if (next.has(decadeId)) {
-      next.delete(decadeId);
-    } else {
-      next.add(decadeId);
-    }
-    setSelectedDecades(next);
-    onDecadeSelectionChange([...next]);
+    setSelectedDecades((prev) => {
+      const next = new Set(prev);
+      if (next.has(decadeId)) {
+        next.delete(decadeId);
+      } else {
+        next.add(decadeId);
+      }
+      return next;
+    });
   };
 
   // Clear all selections
   const clearAll = () => {
     setSelectedDecades(new Set());
-    onDecadeSelectionChange([]);
   };
 
   // Check if a decade is selected
@@ -167,7 +165,8 @@ export default function DecadesFilter({
                   key={decade.id}
                   value={decade.name}
                   onSelect={() => {
-                    toggleDecade(decade.id);
+                    toggleDecade(decade.id)
+                    toast(`You selected the ${decade.name} decade but's the feature isn't implemented yet 🙃`);
                   }}
                   className="flex items-center gap-2"
                 >

--- a/src/components/GenreInfo.tsx
+++ b/src/components/GenreInfo.tsx
@@ -11,7 +11,7 @@ import ReportIncorrectInfoDialog from "@/components/ReportIncorrectInfoDialog";
 import { toast } from "sonner";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import ArtistBadge from "@/components/ArtistBadge";
-import { BadgeIndicator } from "@/components/BadgeIndicator";
+import ArtistAvatar from "@/components/ArtistAvatar";
 import GenreBadge from "@/components/GenreBadge";
 import { SplitButton, SplitButtonAction, SplitButtonTrigger } from "@/components/ui/split-button";
 import {
@@ -603,8 +603,7 @@ export function GenreInfo({
                             title={`Go to ${artist.name}`}
                             className="flex flex-col items-center gap-2 flex-none w-auto group"
                           >
-                            <BadgeIndicator
-                              type="artist"
+                            <ArtistAvatar
                               name={artist.name}
                               imageUrl={img}
                               color={accent}

--- a/src/components/GenreInfo.tsx
+++ b/src/components/GenreInfo.tsx
@@ -593,6 +593,7 @@ export function GenreInfo({
                     <div className="grid grid-cols-4 gap-4 w-full pb-1 -mx-1 px-1">
                       {topArtists.map((artist) => {
                         const accent = getArtistColor(artist!);
+                        const isInView = !!artist;
                         const img = typeof artist.image === 'string' && artist.image.trim()
                           ? fixWikiImageURL(artist.image as string)
                           : undefined;
@@ -607,6 +608,7 @@ export function GenreInfo({
                               name={artist.name}
                               imageUrl={img}
                               color={accent}
+                              isInView={isInView}
                               className="size-[64px] border-2 ring-2 ring-transparent group-hover:ring-primary/30 group-hover:scale-105 transition-all duration-200"
                               labelClassName="text-base"
                             />

--- a/src/components/GenreInfo.tsx
+++ b/src/components/GenreInfo.tsx
@@ -11,6 +11,7 @@ import ReportIncorrectInfoDialog from "@/components/ReportIncorrectInfoDialog";
 import { toast } from "sonner";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import ArtistBadge from "@/components/ArtistBadge";
+import { BadgeIndicator } from "@/components/BadgeIndicator";
 import GenreBadge from "@/components/GenreBadge";
 import { SplitButton, SplitButtonAction, SplitButtonTrigger } from "@/components/ui/split-button";
 import {
@@ -587,29 +588,36 @@ export function GenreInfo({
                 )}
                 {/* Top Artists */}
                 {topArtists && topArtists.length > 0 && (
-                  <div className="flex flex-col gap-2">
+                  <div className="flex flex-col gap-3">
                     <span className="text-md font-semibold">Top Artists</span>
-                    <div className="flex flex-wrap items-center gap-1.5">
-                    {topArtists.map((artist) => {
-                      const accent = getArtistColor(artist!);
-                      const img = typeof artist.image === 'string' && artist.image.trim()
-                        ? fixWikiImageURL(artist.image as string)
-                        : undefined;
-                      const initial = artist.name?.[0]?.toUpperCase() ?? '?';
-                      return (
-                        <ArtistBadge
+                    <div className="grid grid-cols-4 gap-4 w-full pb-1 -mx-1 px-1">
+                      {topArtists.map((artist) => {
+                        const accent = getArtistColor(artist!);
+                        const img = typeof artist.image === 'string' && artist.image.trim()
+                          ? fixWikiImageURL(artist.image as string)
+                          : undefined;
+                        return (
+                          <button
                             key={artist.name}
-                            name={artist.name}
-                            imageUrl={img}
-                            genreColor={accent}
-                            onClick={() =>onTopArtistClick?.(artist)}
+                            onClick={() => onTopArtistClick?.(artist)}
                             title={`Go to ${artist.name}`}
-                          />
-                      );
-                    })}
+                            className="flex flex-col items-center gap-2 flex-none w-auto group"
+                          >
+                            <BadgeIndicator
+                              type="artist"
+                              name={artist.name}
+                              imageUrl={img}
+                              color={accent}
+                              className="size-[64px] ring-2 ring-transparent group-hover:ring-primary/30 group-hover:scale-105 transition-all duration-200"
+                              labelClassName="text-base"
+                            />
+                            <span className="text-[11px] leading-tight text-center line-clamp-2 w-full font-semibold group-hover:text-foreground transition-colors">
+                              {artist.name}
+                            </span>
+                          </button>
+                        );
+                      })}
                     </div>
-                
-                
                   </div>
                 )}
 

--- a/src/components/GenreInfo.tsx
+++ b/src/components/GenreInfo.tsx
@@ -608,7 +608,7 @@ export function GenreInfo({
                               name={artist.name}
                               imageUrl={img}
                               color={accent}
-                              className="size-[64px] ring-2 ring-transparent group-hover:ring-primary/30 group-hover:scale-105 transition-all duration-200"
+                              className="size-[64px] border-2 ring-2 ring-transparent group-hover:ring-primary/30 group-hover:scale-105 transition-all duration-200"
                               labelClassName="text-base"
                             />
                             <span className="text-[11px] leading-tight text-center line-clamp-2 w-full font-semibold group-hover:text-foreground transition-colors">

--- a/src/components/GenreInfo.tsx
+++ b/src/components/GenreInfo.tsx
@@ -593,7 +593,6 @@ export function GenreInfo({
                     <div className="grid grid-cols-4 gap-4 w-full pb-1 -mx-1 px-1">
                       {topArtists.map((artist) => {
                         const accent = getArtistColor(artist!);
-                        const isInView = !!artist;
                         const img = typeof artist.image === 'string' && artist.image.trim()
                           ? fixWikiImageURL(artist.image as string)
                           : undefined;
@@ -608,7 +607,6 @@ export function GenreInfo({
                               name={artist.name}
                               imageUrl={img}
                               color={accent}
-                              isInView={isInView}
                               className="size-[64px] border-2 ring-2 ring-transparent group-hover:ring-primary/30 group-hover:scale-105 transition-all duration-200"
                               labelClassName="text-base"
                             />

--- a/src/components/GenreInfo.tsx
+++ b/src/components/GenreInfo.tsx
@@ -607,7 +607,7 @@ export function GenreInfo({
                               name={artist.name}
                               imageUrl={img}
                               color={accent}
-                              className="size-[64px] border-2 ring-2 ring-transparent group-hover:ring-primary/30 group-hover:scale-105 transition-all duration-200"
+                              className="size-[64px]"
                               labelClassName="text-base"
                             />
                             <span className="text-[11px] leading-tight text-center line-clamp-2 w-full font-semibold group-hover:text-foreground transition-colors">

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -1,7 +1,6 @@
 import {
   forwardRef,
   memo,
-  useCallback,
   useEffect,
   useImperativeHandle,
   useMemo,
@@ -88,212 +87,6 @@ export type NodeRenderer<T> = (ctx: NodeRenderContext<T>) => void;
 export type SelectionRenderer<T> = (ctx: SelectionRenderContext<T>) => void;
 export type LabelRenderer<T> = (ctx: LabelRenderContext<T>) => void;
 
-export interface ClusterOverlay {
-  id: string;
-  name: string;
-  color: string;
-  nodeIds: Set<string>;
-}
-
-// --- Cluster hull drawing helpers ---
-
-function hexToRgba(hex: string, alpha: number): string {
-  const r = parseInt(hex.slice(1, 3), 16);
-  const g = parseInt(hex.slice(3, 5), 16);
-  const b = parseInt(hex.slice(5, 7), 16);
-  return `rgba(${r},${g},${b},${alpha})`;
-}
-
-function cross2d(O: [number, number], A: [number, number], B: [number, number]): number {
-  return (A[0] - O[0]) * (B[1] - O[1]) - (A[1] - O[1]) * (B[0] - O[0]);
-}
-
-function computeConvexHull(pts: [number, number][]): [number, number][] {
-  const n = pts.length;
-  if (n < 2) return [...pts];
-  const sorted = [...pts].sort((a, b) => a[0] !== b[0] ? a[0] - b[0] : a[1] - b[1]);
-  const lower: [number, number][] = [];
-  for (const p of sorted) {
-    while (lower.length >= 2 && cross2d(lower[lower.length - 2], lower[lower.length - 1], p) <= 0) lower.pop();
-    lower.push(p);
-  }
-  const upper: [number, number][] = [];
-  for (let i = n - 1; i >= 0; i--) {
-    const p = sorted[i];
-    while (upper.length >= 2 && cross2d(upper[upper.length - 2], upper[upper.length - 1], p) <= 0) upper.pop();
-    upper.push(p);
-  }
-  lower.pop();
-  upper.pop();
-  return [...lower, ...upper];
-}
-
-// Smooth polygon via midpoint-quadratic-bezier (round corners without external deps)
-function drawSmoothPolygon(ctx: CanvasRenderingContext2D, pts: [number, number][]): void {
-  const n = pts.length;
-  if (n === 0) return;
-  const mid = (a: [number, number], b: [number, number]): [number, number] => [(a[0] + b[0]) / 2, (a[1] + b[1]) / 2];
-  const start = mid(pts[n - 1], pts[0]);
-  ctx.moveTo(start[0], start[1]);
-  for (let i = 0; i < n; i++) {
-    const curr = pts[i];
-    const next = pts[(i + 1) % n];
-    const m = mid(curr, next);
-    ctx.quadraticCurveTo(curr[0], curr[1], m[0], m[1]);
-  }
-  ctx.closePath();
-}
-
-type NodePosEntry = { x?: number; y?: number; radius: number };
-
-function buildClusterShape(
-  positions: [number, number][],
-  padding: number,
-  cx: number,
-  cy: number,
-): { kind: 'circle'; x: number; y: number; r: number } | { kind: 'poly'; pts: [number, number][] } {
-  if (positions.length === 1) {
-    return { kind: 'circle', x: positions[0][0], y: positions[0][1], r: padding };
-  }
-  if (positions.length === 2) {
-    const dx = positions[1][0] - positions[0][0];
-    const dy = positions[1][1] - positions[0][1];
-    const len = Math.sqrt(dx * dx + dy * dy) || 1;
-    const nx = (-dy / len) * padding;
-    const ny = (dx / len) * padding;
-    const ax = positions[0][0] - (dx / len) * padding;
-    const ay = positions[0][1] - (dy / len) * padding;
-    const bx = positions[1][0] + (dx / len) * padding;
-    const by = positions[1][1] + (dy / len) * padding;
-    return {
-      kind: 'poly',
-      pts: [
-        [ax + nx, ay + ny],
-        [bx + nx, by + ny],
-        [bx - nx, by - ny],
-        [ax - nx, ay - ny],
-      ],
-    };
-  }
-  const hull = computeConvexHull(positions);
-  const expanded: [number, number][] = hull.map(p => {
-    const dx = p[0] - cx;
-    const dy = p[1] - cy;
-    const len = Math.sqrt(dx * dx + dy * dy);
-    if (len < 1e-6) return [p[0] + padding, p[1]] as [number, number];
-    return [p[0] + (dx / len) * padding, p[1] + (dy / len) * padding] as [number, number];
-  });
-  return { kind: 'poly', pts: expanded };
-}
-
-function traceClusterShape(ctx: CanvasRenderingContext2D, shape: ReturnType<typeof buildClusterShape>): void {
-  ctx.beginPath();
-  if (shape.kind === 'circle') {
-    ctx.arc(shape.x, shape.y, shape.r, 0, 2 * Math.PI);
-  } else {
-    drawSmoothPolygon(ctx, shape.pts);
-  }
-}
-
-const CLUSTER_HULL_PADDING = 48;
-const CLUSTER_LABEL_SCREEN_PX = 13;
-const CLUSTER_LABEL_STROKE_SCREEN_PX = 1.2;
-
-function drawClusterHulls(
-  ctx: CanvasRenderingContext2D,
-  overlays: ClusterOverlay[],
-  nodeMap: Map<string, NodePosEntry>,
-  globalScale: number,
-): void {
-  for (const overlay of overlays) {
-    const positions: [number, number][] = [];
-    for (const id of overlay.nodeIds) {
-      const node = nodeMap.get(id);
-      if (node?.x !== undefined && node.y !== undefined) {
-        positions.push([node.x, node.y]);
-      }
-    }
-    if (positions.length === 0) continue;
-
-    const cx = positions.reduce((s, p) => s + p[0], 0) / positions.length;
-    const cy = positions.reduce((s, p) => s + p[1], 0) / positions.length;
-    const shape = buildClusterShape(positions, CLUSTER_HULL_PADDING, cx, cy);
-
-    let strokeColor: string;
-    let r: number, g: number, b: number;
-    try {
-      r = parseInt(overlay.color.slice(1, 3), 16);
-      g = parseInt(overlay.color.slice(3, 5), 16);
-      b = parseInt(overlay.color.slice(5, 7), 16);
-      strokeColor = hexToRgba(overlay.color, 0.2);
-    } catch {
-      r = 128; g = 128; b = 128;
-      strokeColor = overlay.color + '33';
-    }
-
-    // Radial gradient: transparent center fading to slight color at edges
-    const radius = shape.kind === 'circle'
-      ? shape.r
-      : Math.max(...shape.pts.map(p => Math.hypot(p[0] - cx, p[1] - cy)));
-    const grad = ctx.createRadialGradient(cx, cy, 0, cx, cy, radius + CLUSTER_HULL_PADDING);
-    grad.addColorStop(0, `rgba(${r},${g},${b},0)`);
-    grad.addColorStop(0.6, `rgba(${r},${g},${b},0.02)`);
-    grad.addColorStop(1, `rgba(${r},${g},${b},0.07)`);
-
-    traceClusterShape(ctx, shape);
-    ctx.fillStyle = grad;
-    ctx.fill();
-    ctx.strokeStyle = strokeColor;
-    ctx.lineWidth = CLUSTER_LABEL_STROKE_SCREEN_PX / globalScale;
-    ctx.setLineDash([4 / globalScale, 6 / globalScale]);
-    ctx.stroke();
-    ctx.setLineDash([]);
-  }
-}
-
-function drawClusterLabels(
-  ctx: CanvasRenderingContext2D,
-  overlays: ClusterOverlay[],
-  nodeMap: Map<string, NodePosEntry>,
-  globalScale: number,
-): void {
-  const fontSize = CLUSTER_LABEL_SCREEN_PX / globalScale;
-
-  for (const overlay of overlays) {
-    const positions: [number, number][] = [];
-    for (const id of overlay.nodeIds) {
-      const node = nodeMap.get(id);
-      if (node?.x !== undefined && node.y !== undefined) {
-        positions.push([node.x, node.y]);
-      }
-    }
-    if (positions.length === 0) continue;
-
-    const cx = positions.reduce((s, p) => s + p[0], 0) / positions.length;
-    const minY = Math.min(...positions.map(p => p[1]));
-    const labelY = minY - CLUSTER_HULL_PADDING - fontSize * 0.7;
-
-    let labelColor: string;
-    try {
-      labelColor = hexToRgba(overlay.color, 0.85);
-    } catch {
-      labelColor = overlay.color;
-    }
-
-    ctx.save();
-    ctx.font = `600 ${fontSize}px Inter, system-ui, sans-serif`;
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
-    ctx.fillStyle = labelColor;
-    ctx.shadowColor = 'rgba(0, 0, 0, 0.8)';
-    ctx.shadowBlur = 4;
-    ctx.shadowOffsetX = 0;
-    ctx.shadowOffsetY = 0;
-    ctx.fillText(overlay.name, cx, labelY);
-    ctx.restore();
-  }
-}
-
 export interface GraphProps<T, L extends SharedGraphLink> {
   nodes: SharedGraphNode<T>[];
   links: L[];
@@ -328,8 +121,6 @@ export interface GraphProps<T, L extends SharedGraphLink> {
     nodeToRadius: Map<string, number>;
     strength?: number;
   };
-  // Cluster hull overlays (genre mode)
-  clusterOverlays?: ClusterOverlay[];
 }
 
 type PreparedNode<T> = SharedGraphNode<T> & { x?: number; y?: number };
@@ -401,7 +192,6 @@ const Graph = forwardRef(function GraphInner<
     disableDimming = false,
     priorityLabelIds: priorityLabelIdsProp,
     radialLayout,
-    clusterOverlays,
   }: GraphProps<T, L>,
   ref: Ref<GraphHandle>,
 ) {
@@ -410,7 +200,6 @@ const Graph = forwardRef(function GraphInner<
   const zoomRef = useRef<number>(1);
   const showNodesRef = useRef<boolean>(showNodes);
   const showLinksRef = useRef<boolean>(showLinks);
-  const clusterOverlaysRef = useRef<ClusterOverlay[] | undefined>(undefined);
   const { resolvedTheme } = useTheme();
   const { state: sidebarState } = useSidebar();
   const sidebarExpanded = sidebarState === "expanded";
@@ -438,13 +227,6 @@ const Graph = forwardRef(function GraphInner<
     showNodesRef.current = showNodes;
     showLinksRef.current = showLinks;
   }, [showNodes, showLinks]);
-
-  useEffect(() => {
-    clusterOverlaysRef.current = clusterOverlays;
-    // autoPauseRedraw stops the canvas when the sim is idle, so poke it to
-    // repaint after the overlay data changes (on/off toggle, data update, etc.)
-    fgRef.current?.resumeAnimation?.();
-  }, [clusterOverlays]);
 
   // Convert display control values to usable ranges (all centered at 50 = 1.0x)
   const nodeScaleFactor = useMemo(() => {
@@ -728,7 +510,7 @@ const Graph = forwardRef(function GraphInner<
     // Charge force: nodes repel each other (D3 default is -30)
     // More negative = stronger repulsion/more spread out, Less negative = nodes closer together
     // KEY FIX: Reducing from -200 to -100 greatly reduced the "floating outward" drag effect
-    fg.d3Force("charge")?.strength(dagMode ? -1230 : -190);
+    fg.d3Force("charge")?.strength(dagMode ? -1230 : -120);
 
     // Link force: connected nodes attract each other
     const linkForce = fg.d3Force("link") as d3.ForceLink<PreparedNode<T>, L> | undefined;
@@ -807,61 +589,6 @@ const Graph = forwardRef(function GraphInner<
       lastInitializedSignatureRef.current = signature;
     }
   }, [dataSignature, dagMode, preparedData, selectedId, show, radialLayout]);
-
-  // Cluster centroid force: pulls every node toward its cluster's live centroid each simulation tick.
-  // Uses the same nodeIds that determine cluster color, so the force is always consistent with the overlay.
-  // Runs in a separate effect so it can update independently of the main data signature.
-  useEffect(() => {
-    if (!show || !fgRef.current) return;
-    const fg = fgRef.current;
-
-    if (clusterOverlays && clusterOverlays.length > 0 && !radialLayout?.enabled) {
-      const nodeToClusterId = new Map<string, string>();
-      clusterOverlays.forEach(overlay => {
-        overlay.nodeIds.forEach(nodeId => nodeToClusterId.set(nodeId, overlay.id));
-      });
-
-      const CLUSTER_STRENGTH = 0.12;
-      const simNodes: any[] = [];
-
-      const centroidForce = Object.assign(
-        function(alpha: number) {
-          const centroids = new Map<string, { x: number; y: number; count: number }>();
-          simNodes.forEach(node => {
-            const cid = nodeToClusterId.get(node.id);
-            if (cid === undefined) return;
-            let c = centroids.get(cid);
-            if (!c) { c = { x: 0, y: 0, count: 0 }; centroids.set(cid, c); }
-            c.x += node.x ?? 0;
-            c.y += node.y ?? 0;
-            c.count++;
-          });
-          centroids.forEach(c => { c.x /= c.count; c.y /= c.count; });
-
-          simNodes.forEach(node => {
-            const cid = nodeToClusterId.get(node.id);
-            if (cid === undefined) return;
-            const centroid = centroids.get(cid);
-            if (!centroid) return;
-            node.vx = (node.vx ?? 0) - (node.x - centroid.x) * alpha * CLUSTER_STRENGTH;
-            node.vy = (node.vy ?? 0) - (node.y - centroid.y) * alpha * CLUSTER_STRENGTH;
-          });
-        },
-        {
-          initialize(nodes: any[]) {
-            simNodes.length = 0;
-            simNodes.push(...nodes);
-          },
-        }
-      );
-
-      fg.d3Force('cluster-centroid', centroidForce);
-    } else {
-      fg.d3Force('cluster-centroid', null);
-    }
-
-    fg.d3ReheatSimulation?.();
-  }, [clusterOverlays, radialLayout, show]);
 
   useEffect(() => {
     if (!autoFocus || !show || !selectedId || !fgRef.current) return;
@@ -966,26 +693,6 @@ const Graph = forwardRef(function GraphInner<
     };
   }, [disableDimming]);
 
-  const handleRenderFramePre = useCallback((ctx: CanvasRenderingContext2D, globalScale: number) => {
-    const overlays = clusterOverlaysRef.current;
-    if (!overlays?.length) return;
-    const nodes = preparedDataRef.current?.nodes;
-    if (!nodes?.length) return;
-    const nodeMap = new Map<string, NodePosEntry>();
-    for (const n of nodes) nodeMap.set(n.id, n);
-    drawClusterHulls(ctx, overlays, nodeMap, globalScale);
-  }, []);
-
-  const handleRenderFramePost = useCallback((ctx: CanvasRenderingContext2D, globalScale: number) => {
-    const overlays = clusterOverlaysRef.current;
-    if (!overlays?.length) return;
-    const nodes = preparedDataRef.current?.nodes;
-    if (!nodes?.length) return;
-    const nodeMap = new Map<string, NodePosEntry>();
-    for (const n of nodes) nodeMap.set(n.id, n);
-    drawClusterLabels(ctx, overlays, nodeMap, globalScale);
-  }, []);
-
   return (
     <div
       ref={containerRef}
@@ -1018,7 +725,7 @@ const Graph = forwardRef(function GraphInner<
         dagLevelDistance={dagMode ? 200 : undefined}
         // How quickly the simulation "cools down" (D3 default is 0.0228)
         // Higher = faster settling but less accurate layout, Lower = slower but more precise
-        d3AlphaDecay={0.05}
+        d3AlphaDecay={0.01}
         // Friction/damping on node velocity (D3 default is 0.4, using slightly higher for stability)
         // Higher = nodes stop faster/less drift, Lower = more fluid movement
         d3VelocityDecay={0.4}
@@ -1062,7 +769,7 @@ const Graph = forwardRef(function GraphInner<
               const target = typeof link.target === "string" ? link.target : (link.target as NodeObject)?.id;
               return source === effectiveSelectedId || target === effectiveSelectedId ? 2 : 0.3;
             })()
-          ) : 0.8; // Reduced for less visual noise
+          ) : 0.5; // Reduced for less visual noise
           return baseWidth * linkThicknessScale;
         }}
         linkCurvature={dagMode ? 0 : linkCurvatureValue}
@@ -1200,8 +907,6 @@ const Graph = forwardRef(function GraphInner<
           ctx.fill();
         }}
         nodeVal={(node) => node.radius}
-        onRenderFramePre={handleRenderFramePre}
-        onRenderFramePost={handleRenderFramePost}
       />
       </div>
     </div>

--- a/src/components/Graph/README.md
+++ b/src/components/Graph/README.md
@@ -32,8 +32,6 @@ There is no separate Collections graph component. Collection mode uses the artis
 - A data signature is used to reheat the simulation only when node/link topology changes.
 - Labels fade in/out based on zoom and optional priority label logic.
 - Popularity clustering can enable a radial layout (concentric rings) via `d3.forceRadial`.
-- "By Genre" clustering (collection mode only) groups liked artists by root genre. Genre assignment is pre-computed in App.tsx via `artistGenreAssignments` useMemo and passed to `ClusteringEngine` as `genreAssignments`/`genreColors`/`genreNames`. Intra-genre links use KNN tag-vector similarity for force-directed pull.
-- When clustering by genre, `ClusterOverlay` blobs are drawn on the canvas via `onRenderFramePre` (filled convex hull) and `onRenderFramePost` (cluster name label above the hull). The overlay data flows: `artistClusters` → `artistClusterOverlays` memo in App.tsx → `ArtistsForceGraph.clusterOverlays` → `Graph.clusterOverlays`. The hull uses an inline Graham-scan convex hull with outward padding expansion and smooth quadratic-bezier edges.
 
 ## Entry Points Used by the App
 

--- a/src/components/Graph/graphStyle.ts
+++ b/src/components/Graph/graphStyle.ts
@@ -292,7 +292,7 @@ export function drawSelectedNodeFill(
 
 // Default node radius bounds
 export const DEFAULT_MIN_RADIUS = 3;
-export const DEFAULT_MAX_RADIUS = 25;
+export const DEFAULT_MAX_RADIUS = 35;
 // Exponent for node size scaling (higher = more dramatic size differences)
 export const NODE_SIZE_EXPONENT = 2;
 

--- a/src/components/Graph/index.ts
+++ b/src/components/Graph/index.ts
@@ -10,5 +10,4 @@ export type {
   NodeRenderer,
   SelectionRenderer,
   LabelRenderer,
-  ClusterOverlay,
 } from './Graph';

--- a/src/hooks/useArtists.tsx
+++ b/src/hooks/useArtists.tsx
@@ -169,6 +169,7 @@ const useArtists = (genreIDs: string[], topAmount = TOP_ARTISTS_TO_FETCH, filter
         }
     }
 
+    // Don't use this unless you want very fuzzy results
     const fetchArtistBySearch = async (query: string): Promise<Artist | undefined> => {
         try {
             const response = await axios.get(`${url}/search/${query}`);
@@ -177,6 +178,18 @@ const useArtists = (genreIDs: string[], topAmount = TOP_ARTISTS_TO_FETCH, filter
             return results.find((r): r is Artist => 'listeners' in r);
         } catch {
             return undefined;
+        }
+    }
+
+    const fetchArtistByName = async (name: string): Promise<Artist | undefined> => {
+        resetArtistsError();
+        try {
+            const response = await axios.get(`${url}/artists/fetch/name/${name}`);
+            return response.data;
+        } catch (err) {
+            if (err instanceof AxiosError) {
+                setArtistsError(err);
+            }
         }
     }
 
@@ -197,6 +210,7 @@ const useArtists = (genreIDs: string[], topAmount = TOP_ARTISTS_TO_FETCH, filter
     const prefetchSimilarImages = async (artist: Artist): Promise<Artist[]> => {
         try {
             const response = await axios.get(`${url}/artists/fetch/similar/${artist.id}`);
+            setSimilarArtists([artist, ...response.data]);
             return [artist, ...response.data] as Artist[];
         } catch {
             return [];
@@ -231,6 +245,7 @@ const useArtists = (genreIDs: string[], topAmount = TOP_ARTISTS_TO_FETCH, filter
         similarArtists,
         fetchSimilarArtists,
         prefetchSimilarImages,
+        fetchArtistByName,
     };
 }
 

--- a/src/hooks/useArtists.tsx
+++ b/src/hooks/useArtists.tsx
@@ -6,7 +6,7 @@ import {DEFAULT_NODE_COUNT, MAX_NODES, TOP_ARTISTS_TO_FETCH} from "@/constants";
 
 const url = serverUrl();
 
-const useArtists = (genreIDs: string[], topAmount = TOP_ARTISTS_TO_FETCH, filter: ArtistNodeLimitType, amount: number, initial: boolean, collectionMode = false, decades: string[] = []) => {
+const useArtists = (genreIDs: string[], topAmount = TOP_ARTISTS_TO_FETCH, filter: ArtistNodeLimitType, amount: number, initial: boolean, collectionMode = false) => {
     const [artists, setArtists] = useState<Artist[]>([]);
     const [artistLinks, setArtistLinks] = useState<NodeLink[]>([]);
     const [artistsLoading, setArtistsLoading] = useState(false);
@@ -23,36 +23,25 @@ const useArtists = (genreIDs: string[], topAmount = TOP_ARTISTS_TO_FETCH, filter
         resetArtistsError();
         if (!initial) {
             setArtistsLoading(true);
+            // console.log(`fetching ${amount} artists...`);
             try {
-                if (decades.length > 0) {
-                    const response = await axios.post(`${url}/artists/by-decades`, {
-                        decades,
-                        filter,
-                        amount,
-                        ...(genreIDs.length > 0 && { genres: genreIDs }),
-                    });
+                const selectedSize = genreIDs.length;
+                if (selectedSize === 0) {
+                    const response = await axios.get(`${url}/artists/${filter}/${amount}`);
                     setArtists(response.data.artists);
                     setArtistLinks(response.data.links);
                     setTotalArtistsInDB(response.data.count);
-                } else {
-                    const selectedSize = genreIDs.length;
-                    if (selectedSize === 0) {
-                        const response = await axios.get(`${url}/artists/${filter}/${amount}`);
-                        setArtists(response.data.artists);
-                        setArtistLinks(response.data.links);
-                        setTotalArtistsInDB(response.data.count);
-                    }
-                    if (selectedSize > 0) {
-                        const response = await axios.post(`${url}/artists/${filter}/${amount}`, {genres: genreIDs});
-                        const artistCount = response.data.artists.length;
-                        setArtists(response.data.artists);
-                        setArtistLinks(response.data.links);
-                        setTotalArtistsInDB(
-                            response.data.count > amount
-                                ? response.data.count
-                                : artistCount
-                        );
-                    }
+                }
+                if (selectedSize > 0) {
+                    const response = await axios.post(`${url}/artists/${filter}/${amount}`, {genres: genreIDs});
+                    const artistCount = response.data.artists.length;
+                    setArtists(response.data.artists);
+                    setArtistLinks(response.data.links);
+                    setTotalArtistsInDB(
+                        response.data.count > amount
+                            ? response.data.count
+                            : artistCount
+                    );
                 }
             } catch (err) {
                 if (err instanceof AxiosError) {
@@ -102,7 +91,7 @@ const useArtists = (genreIDs: string[], topAmount = TOP_ARTISTS_TO_FETCH, filter
         if (!collectionMode) {
             fetchArtists();
         }
-    }, [genreIDs, filter, initial, collectionMode, decades]);
+    }, [genreIDs, filter, initial, collectionMode]);
 
     // Only refetch if change in amount is more than current amount of artists
     useEffect(() => {

--- a/src/hooks/useArtists.tsx
+++ b/src/hooks/useArtists.tsx
@@ -194,6 +194,15 @@ const useArtists = (genreIDs: string[], topAmount = TOP_ARTISTS_TO_FETCH, filter
         setArtistsLoading(false);
     }
 
+    const prefetchSimilarImages = async (artist: Artist): Promise<Artist[]> => {
+        try {
+            const response = await axios.get(`${url}/artists/fetch/similar/${artist.id}`);
+            return [artist, ...response.data] as Artist[];
+        } catch {
+            return [];
+        }
+    }
+
     const resetArtistsError = () => setArtistsError(undefined);
     const resetArtistsYTError = () => setArtistsPlayIDsError(undefined);
     const resetArtistsDataFlagError = () => setArtistsDataFlagError(undefined);
@@ -221,6 +230,7 @@ const useArtists = (genreIDs: string[], topAmount = TOP_ARTISTS_TO_FETCH, filter
         fetchArtistBySearch,
         similarArtists,
         fetchSimilarArtists,
+        prefetchSimilarImages,
     };
 }
 

--- a/src/lib/ClusteringEngine.ts
+++ b/src/lib/ClusteringEngine.ts
@@ -3,9 +3,9 @@ import { ARTIST_LISTENER_TIERS } from '@/constants';
 import Graph from 'graphology';
 import louvain from 'graphology-communities-louvain';
 import { buildNormalizedLocationMap, calculateLocationSimilarity } from './locationNormalization';
-import { getClusterColor, DEFAULT_DARK_NODE_COLOR, DEFAULT_LIGHT_NODE_COLOR } from "@/lib/colors";
+import {getClusterColor} from "@/lib/colors";
 
-export type ClusteringMethod = 'similarArtists' | 'byTags' | 'popularity' | 'genre';
+export type ClusteringMethod = 'similarArtists' | 'hybrid' | 'popularity';
 
 export interface ClusterResult {
   method: ClusteringMethod;
@@ -35,18 +35,13 @@ export interface Cluster {
 export interface ClusteringOptions {
   method: ClusteringMethod;
   resolution?: number;  // For Louvain
-  tagWeights?: {
+  hybridWeights?: {
     vectors: number;
     louvain: number;
     location: number;  // Weight for location-based similarity (default: 0.2)
   };
   kNeighbors?: number;  // Number of nearest neighbors to keep (default: 20)
   minSimilarity?: number;  // Minimum similarity threshold (0-1, default: 0.1)
-  // Only required when method === 'genre'
-  genreAssignments?: Map<string, string>;       // artistId -> rootGenreId
-  genreColors?: Map<string, string>;            // rootGenreId -> hex color
-  genreNames?: Map<string, string>;             // rootGenreId -> display name
-  artistPrimaryGenreTags?: Map<string, string>; // artistId -> top genre tag name (e.g. "black metal")
 }
 
 export class ClusteringEngine {
@@ -100,17 +95,10 @@ export class ClusteringEngine {
     switch (options.method) {
       case 'similarArtists':
         return this.clusterByLouvain(options.resolution || 1.0);
-      case 'byTags':
-        return this.clusterByTags(options.resolution || 1.0, options.tagWeights, kNeighbors, minSimilarity);
+      case 'hybrid':
+        return this.clusterHybrid(options.resolution || 1.0, options.hybridWeights, kNeighbors, minSimilarity);
       case 'popularity':
         return this.clusterByListeners();
-      case 'genre':
-        return this.clusterByGenre(
-          options.genreAssignments ?? new Map(),
-          options.genreColors ?? new Map(),
-          options.genreNames,
-          options.artistPrimaryGenreTags
-        );
       default:
         return this.clusterByLouvain(options.resolution || 1.0);
     }
@@ -210,12 +198,12 @@ export class ClusteringEngine {
     return this.formatLouvainClusters(communities, 'similarArtists', networkSim, minLinkWeight);
   }
 
-  // 3. BY TAGS CLUSTERING - Louvain with combined weighted edges
-  private clusterByTags(
+  // 3. HYBRID CLUSTERING - Louvain with combined weighted edges
+  private clusterHybrid(
     resolution: number,
     weights = { vectors: 0.6, louvain: 0.4, location: 0.3 },
     kNeighbors: number = 15,
-    minSimilarity: number = 0.8
+    minSimilarity: number = 0.2
   ): ClusterResult {
     // Normalize vector/louvain weights to sum to 1.0 (location is a separate multiplier)
     const baseTotal = weights.vectors + weights.louvain;
@@ -283,8 +271,8 @@ export class ClusteringEngine {
       penalizedSim.set(key, sim * multiplier);
     });
 
-    //console.log(`[byTags] Combined similarities: vectors=${vectorSim.size}, network=${networkSim.size}`);
-    //console.log(`[byTags] Location penalties applied: same=${penaltyStats.same}, region=${penaltyStats.region}, different=${penaltyStats.different}`);
+    //console.log(`[hybrid] Combined similarities: vectors=${vectorSim.size}, network=${networkSim.size}`);
+    //console.log(`[hybrid] Location penalties applied: same=${penaltyStats.same}, region=${penaltyStats.region}, different=${penaltyStats.different}`);
 
     // Filter out weak similarities to reduce graph complexity
     // After location penalty, more edges will fall below threshold
@@ -300,9 +288,9 @@ export class ClusteringEngine {
       }
     });
 
-    //console.log(`[byTags] Filtered from ${penalizedSim.size} to ${filteredCombinedSim.size} edges (min weight: ${minCombinedWeight.toFixed(3)})`);
+    //console.log(`[hybrid] Filtered from ${penalizedSim.size} to ${filteredCombinedSim.size} edges (min weight: ${minCombinedWeight.toFixed(3)})`);
 
-    // Ensure each artist has at least one edge in the byTags graph.
+    // Ensure each artist has at least one edge in the hybrid graph.
     const degreeByArtist = new Map<string, number>();
     this.artists.forEach(artist => {
       degreeByArtist.set(artist.id, 0);
@@ -384,12 +372,8 @@ export class ClusteringEngine {
     const graph = this.buildWeightedGraph(filteredCombinedSim);
     const communities = louvain(graph, { resolution, randomWalk: false });
 
-    // Get initial result and apply degree capping to reduce density
-    const result = this.formatLouvainClusters(communities, 'byTags', filteredCombinedSim, minCombinedWeight);
-    if (result.links && result.links.length > 0) {
-      result.links = this.capNodeDegree(result.links, 12);
-    }
-    return result;
+    // Reuse artistCount from above
+    return this.formatLouvainClusters(communities, 'hybrid', filteredCombinedSim, minCombinedWeight);
   }
 
   // 4. POPULARITY CLUSTERING - Dynamic percentile-based popularity tiers
@@ -444,104 +428,6 @@ export class ClusteringEngine {
         tiers: dynamicTiers,
       },
     };
-  }
-
-  // 5. GENRE CLUSTERING
-  // Bond hierarchy:
-  //   1. Shared primary genre tag (e.g. "black metal") → guaranteed link regardless of cosine sim
-  //   2. Shared parent genre (same cluster) → KNN backbone with BASE_WEIGHT floor
-  //   3. Full tag cosine similarity → boosts weight within both groups
-  private clusterByGenre(
-    genreAssignments: Map<string, string>,
-    genreColors: Map<string, string>,
-    genreNames?: Map<string, string>,
-    artistPrimaryGenreTags?: Map<string, string>,
-  ): ClusterResult {
-    const clusters = new Map<string, Cluster>();
-    const artistToCluster = new Map<string, string>();
-
-    // Assign each artist to its root genre cluster
-    this.artists.forEach(artist => {
-      const rootGenreId = genreAssignments.get(artist.id) ?? 'unknown';
-      const clusterId = `genre-${rootGenreId}`;
-      if (!clusters.has(clusterId)) {
-        clusters.set(clusterId, {
-          id: clusterId,
-          name: genreNames?.get(rootGenreId) ?? (rootGenreId === 'unknown' ? 'Unknown Genre' : rootGenreId),
-          artistIds: [],
-          color: genreColors.get(rootGenreId) ?? (this.isDark ? DEFAULT_DARK_NODE_COLOR : DEFAULT_LIGHT_NODE_COLOR),
-        });
-      }
-      clusters.get(clusterId)!.artistIds.push(artist.id);
-      artistToCluster.set(artist.id, clusterId);
-    });
-
-    const vectors = this.buildTagVectors();
-    const BASE_WEIGHT = 0.2;
-    const K_INTRA = 8;
-    const seen = new Set<string>();
-    const intraClusterLinks: Array<{ source: string; target: string; weight: number }> = [];
-
-    const addLink = (a: string, b: string, weight: number) => {
-      const key = a < b ? `${a}|${b}` : `${b}|${a}`;
-      if (!seen.has(key)) {
-        seen.add(key);
-        intraClusterLinks.push({ source: a, target: b, weight });
-      }
-    };
-
-    clusters.forEach((cluster) => {
-      const ids = cluster.artistIds;
-      if (ids.length <= 1) return;
-
-      // --- Pass 1: guarantee links for artists sharing the same primary genre tag ---
-      // TF-IDF cosine sim can rank artists with the same specific genre tag (e.g. "black metal")
-      // below K_INTRA if their broader tag profiles diverge. This pass fixes that.
-      if (artistPrimaryGenreTags) {
-        const byTag = new Map<string, string[]>();
-        ids.forEach(id => {
-          const tag = artistPrimaryGenreTags.get(id);
-          if (tag) {
-            if (!byTag.has(tag)) byTag.set(tag, []);
-            byTag.get(tag)!.push(id);
-          }
-        });
-
-        byTag.forEach(tagGroup => {
-          if (tagGroup.length <= 1) return;
-          tagGroup.forEach(a => {
-            tagGroup.forEach(b => {
-              if (a >= b) return;
-              const vecA = vectors.get(a);
-              const vecB = vectors.get(b);
-              const tagSim = vecA && vecB ? this.cosineSimilarity(vecA, vecB) : 0;
-              addLink(a, b, BASE_WEIGHT + (1 - BASE_WEIGHT) * tagSim);
-            });
-          });
-        });
-      }
-
-      // --- Pass 2: KNN backbone — connect each artist to its K nearest cluster-mates ---
-      // BASE_WEIGHT floor ensures same-parent-genre nodes always attract even with zero shared tags.
-      ids.forEach((artistId) => {
-        const vecA = vectors.get(artistId);
-        const scores: Array<{ id: string; weight: number }> = [];
-
-        ids.forEach((otherId) => {
-          if (otherId === artistId) return;
-          const vecB = vectors.get(otherId);
-          const tagSim = vecA && vecB ? this.cosineSimilarity(vecA, vecB) : 0;
-          scores.push({ id: otherId, weight: BASE_WEIGHT + (1 - BASE_WEIGHT) * tagSim });
-        });
-
-        scores.sort((a, b) => b.weight - a.weight);
-        scores.slice(0, K_INTRA).forEach(({ id, weight }) => addLink(artistId, id, weight));
-      });
-    });
-
-    const links = this.capNodeDegree(intraClusterLinks, 10);
-
-    return { method: 'genre', clusters, artistToCluster, links, stats: this.calculateStats(clusters) };
   }
 
   // Build dynamic tiers based on percentiles of actual listener data
@@ -689,7 +575,7 @@ export class ClusteringEngine {
     // Adaptive link weight threshold based on method and graph size
     const artistCount = this.artists.length;
     const minLinkWeight = minLinkWeightOverride ?? (
-      method === 'byTags' && artistCount > 1000
+      method === 'hybrid' && artistCount > 1000
         ? 0.25  // Higher threshold for expensive methods on large graphs
         : 0.2   // Standard threshold
     );
@@ -723,9 +609,8 @@ export class ClusteringEngine {
   private getClusterLabel(method: ClusteringMethod): string {
     switch (method) {
       case 'similarArtists': return 'Similar Artists';
-      case 'byTags': return 'By Tags';
+      case 'hybrid': return 'Hybrid';
       case 'popularity': return 'Popularity';
-      case 'genre': return 'Genre';
       default: return 'Similar Artists';
     }
   }
@@ -816,48 +701,6 @@ export class ClusteringEngine {
   }
 
   // STATS AND UTILITIES
-
-  // Cap node degree by keeping only strongest mutual connections
-  private capNodeDegree(
-    links: Array<{ source: string; target: string; weight: number }>,
-    maxDegreePerNode: number
-  ): Array<{ source: string; target: string; weight: number }> {
-    const nodeConnections = new Map<string, Array<{ otherId: string; weight: number }>>();
-
-    // Collect connections for each node
-    links.forEach(({ source, target, weight }) => {
-      if (!nodeConnections.has(source)) nodeConnections.set(source, []);
-      if (!nodeConnections.has(target)) nodeConnections.set(target, []);
-
-      nodeConnections.get(source)!.push({ otherId: target, weight });
-      nodeConnections.get(target)!.push({ otherId: source, weight });
-    });
-
-    // Keep only top connections per node by weight
-    const topConnectionsByNode = new Map<string, Set<string>>();
-    nodeConnections.forEach((connections, nodeId) => {
-      connections.sort((a, b) => b.weight - a.weight);
-      const topK = connections.slice(0, maxDegreePerNode);
-      topConnectionsByNode.set(nodeId, new Set(topK.map(c => c.otherId)));
-    });
-
-    // Build result: only include if both endpoints kept each other
-    const result: Array<{ source: string; target: string; weight: number }> = [];
-    const addedEdges = new Set<string>();
-
-    links.forEach(({ source, target, weight }) => {
-      const key = source < target ? `${source}|${target}` : `${target}|${source}`;
-
-      if (!addedEdges.has(key) &&
-          topConnectionsByNode.get(source)?.has(target) &&
-          topConnectionsByNode.get(target)?.has(source)) {
-        result.push({ source, target, weight });
-        addedEdges.add(key);
-      }
-    });
-
-    return result;
-  }
 
   private calculateStats(clusters: Map<string, Cluster>) {
     const sizes = Array.from(clusters.values()).map(c => c.artistIds.length);

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -4,7 +4,7 @@ This folder holds the clustering and centrality logic used by the artists/genres
 
 ## What This Module Contains
 
-- `ClusteringEngine.ts` - artist clustering methods (similarArtists, hybrid, popularity, genre).
+- `ClusteringEngine.ts` - artist clustering methods (similarArtists, hybrid, popularity).
 - `CentralityMetrics.ts` - graph centrality + lightweight helpers for priority labels.
 - `locationNormalization.ts` - normalizes location strings for clustering penalties.
 - `fixedOrderedMap.ts` - small utility used by graph data handling.
@@ -24,11 +24,10 @@ Artist[] + NodeLink[]
 ## Clustering Methods (high level)
 
 - `similarArtists`: Louvain community detection on the existing similar-artist network.
-- `hybrid`: weighted blend of tag-vector similarity + network links, with an optional location penalty. (Currently unused in the UI — replaced by `genre` for collection mode.)
+- `hybrid`: weighted blend of tag-vector similarity + network links, with an optional location penalty.
 - `popularity`: percentile-based listener tiers (used for radial layout in the UI).
-- `genre`: deterministic assignment by root genre (Rock, Electronic, etc.). Requires `genreAssignments`, `genreColors`, and `genreNames` in `ClusteringOptions`. Intra-cluster links use a two-factor model: shared parent genre is the primary bond (every cluster-mate gets a guaranteed `BASE_WEIGHT=0.2` attraction so same-parent nodes always pull together), and tag-vector cosine similarity boosts the weight up to 1.0 as a secondary factor. Each artist connects to its top-8 cluster-mates by this combined score. Only surfaced in collection mode.
 
-`popularity` returns `tierData` for concentric-ring layouts. `genre` requires pre-computed genre maps passed from App.tsx via `ClusteringOptions`.
+`popularity` returns `tierData` for concentric-ring layouts. `hybrid` uses normalized locations to penalize cross-region edges.
 
 ## Centrality
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,7 +63,7 @@ export type GraphType = 'genres' | 'artists' | 'similarArtists' | 'parentGenre';
 
 export type GenreClusterMode = 'subgenre' | 'influence' | 'fusion';
 
-export type ArtistClusterMode = 'similarArtists' | 'byTags' | 'popularity' | 'genre';
+export type ArtistClusterMode = 'similarArtists' | 'hybrid' | 'popularity';
 
 export type LinkType = GenreClusterMode | 'similar';
 


### PR DESCRIPTION
## Changes

### Similar artist avatar images
- Out-of-view similar artists now show their image instead of a letter initial (most of the time)
- On artist selection, similar artist data is prefetched from the backend and images are cached
- Cache check prevents redundant requests when re-selecting previously viewed artists

### Similar artists navigation
- Clicking a similar artist card always opens that artist in the ArtistInfo panel. If currentArtists DOES NOT INCLUDE, ArtistInfo updates to selected artist and graph is undimmed. If currentArtists INCLUDES the selected artists, ArtistInfo updates to selected artist and the node is focused in the graph 
- New `ArtistAvatar` component with genre-colored state badges replaces the previous inline avatar logic. color badges show if artist is in the graph view
- Removed out-of-view chevron badge from ArtistAvatar in similar artists grid
- More explicit "Graph" button added to the Similar Artists and Explore related genres section header as the dedicated entry point to these graph modes. UI could prob be cleaner here, but I wanted to call these modes out more clearly as we got feedback that they were missed.
- Selecting an off-graph artist now deselects the current graph node to avoid stale selection state

