### PR TITLE
feat: Decades

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -296,7 +296,7 @@ function App() {
     fetchSingleArtist,
     similarArtists,
     fetchSimilarArtists,
-  } = useArtists(artistQueryGenreIDs, TOP_ARTISTS_TO_FETCH, artistNodeLimitType, artistNodeCount, isBeforeArtistLoad, collectionMode);
+  } = useArtists(artistQueryGenreIDs, TOP_ARTISTS_TO_FETCH, artistNodeLimitType, artistNodeCount, isBeforeArtistLoad, collectionMode, selectedDecades);
 
   // Fetch top artists for the currently displayed genre info or the active filter
   const [topArtistsGenreId, setTopArtistsGenreId] = useState<string | undefined>(undefined);
@@ -2288,7 +2288,6 @@ function App() {
 
   const onDecadeSelectionChange = (selectedIDs: string[]) => {
     setSelectedDecades(selectedIDs);
-    // TODO: Implement decade filtering logic
   }
 
   // Generic collection filter handler - works for any filter type

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -720,14 +720,19 @@ function App() {
       );
     }
 
-    // Apply decade filter (if any decades selected)
-    // TODO: Implement when decade data is available on artists
-    // if (collectionFilters.decades.length > 0) {
-    //   filtered = filtered.filter(artist => {
-    //     const decade = getArtistDecade(artist);
-    //     return collectionFilters.decades.includes(decade);
-    //   });
-    // }
+    if (collectionMode && collectionFilters.decades.length > 0) {
+      filtered = filtered.filter(artist => {
+        if (!artist.startDate || artist.startDate.length < 4) return false;
+        const startYear = parseInt(artist.startDate.substring(0, 4));
+        const endYear = artist.endDate && artist.endDate.length >= 4
+          ? parseInt(artist.endDate.substring(0, 4))
+          : null;
+        return collectionFilters.decades.some(decade => {
+          const decadeStart = parseInt(decade.replace('s', ''));
+          return startYear <= decadeStart + 9 && (endYear === null || endYear >= decadeStart);
+        });
+      });
+    }
 
     // Apply node limit - sort by the limit type and take top N
     if (filtered.length > artistNodeCount) {
@@ -2705,12 +2710,10 @@ function App() {
                       selectedGenreIds={collectionFilters.genres}
                       genreColorMap={genreColorMap}
                     />
-                    {/* TODO: Add DecadesFilter when ready
                     <DecadesFilter
                       onDecadeSelectionChange={(ids) => onCollectionFilterChange('decades', ids)}
                       selectedDecadeIds={collectionFilters.decades}
                     />
-                    */}
                   </motion.div>
                 )}
               </AnimatePresence>

--- a/src/components/DecadesFilter.tsx
+++ b/src/components/DecadesFilter.tsx
@@ -12,7 +12,6 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
-import { toast } from "sonner";
 
 // Dummy data: decades from 1930s to 2020s
 const DECADES = [
@@ -165,8 +164,7 @@ export default function DecadesFilter({
                   key={decade.id}
                   value={decade.name}
                   onSelect={() => {
-                    toggleDecade(decade.id)
-                    toast(`You selected the ${decade.name} decade but's the feature isn't implemented yet 🙃`);
+                    toggleDecade(decade.id);
                   }}
                   className="flex items-center gap-2"
                 >

--- a/src/components/DecadesFilter.tsx
+++ b/src/components/DecadesFilter.tsx
@@ -29,13 +29,22 @@ const DECADES = [
 
 interface DecadesFilterProps {
   onDecadeSelectionChange: (selectedIds: string[]) => void;
+  selectedDecadeIds?: string[];
 }
 
 export default function DecadesFilter({
   onDecadeSelectionChange,
+  selectedDecadeIds,
 }: DecadesFilterProps) {
-  // Track selected decades using a Set
-  const [selectedDecades, setSelectedDecades] = useState<Set<string>>(new Set());
+  const [selectedDecades, setSelectedDecades] = useState<Set<string>>(
+    new Set(selectedDecadeIds ?? [])
+  );
+
+  useEffect(() => {
+    if (selectedDecadeIds !== undefined) {
+      setSelectedDecades(new Set(selectedDecadeIds));
+    }
+  }, [selectedDecadeIds]);
   const [query, setQuery] = useState("");
 
   // Get selected decades as array for display
@@ -44,28 +53,22 @@ export default function DecadesFilter({
     [selectedDecades]
   );
 
-  // Notify parent component when selection changes
-  useEffect(() => {
-    const ids = selectedDecadesArray.map(d => d.id);
-    onDecadeSelectionChange(ids);
-  }, [selectedDecadesArray]);
-
   // Toggle a decade selection
   const toggleDecade = (decadeId: string) => {
-    setSelectedDecades((prev) => {
-      const next = new Set(prev);
-      if (next.has(decadeId)) {
-        next.delete(decadeId);
-      } else {
-        next.add(decadeId);
-      }
-      return next;
-    });
+    const next = new Set(selectedDecades);
+    if (next.has(decadeId)) {
+      next.delete(decadeId);
+    } else {
+      next.add(decadeId);
+    }
+    setSelectedDecades(next);
+    onDecadeSelectionChange([...next]);
   };
 
   // Clear all selections
   const clearAll = () => {
     setSelectedDecades(new Set());
+    onDecadeSelectionChange([]);
   };
 
   // Check if a decade is selected

--- a/src/hooks/useArtists.tsx
+++ b/src/hooks/useArtists.tsx
@@ -6,7 +6,7 @@ import {DEFAULT_NODE_COUNT, MAX_NODES, TOP_ARTISTS_TO_FETCH} from "@/constants";
 
 const url = serverUrl();
 
-const useArtists = (genreIDs: string[], topAmount = TOP_ARTISTS_TO_FETCH, filter: ArtistNodeLimitType, amount: number, initial: boolean, collectionMode = false) => {
+const useArtists = (genreIDs: string[], topAmount = TOP_ARTISTS_TO_FETCH, filter: ArtistNodeLimitType, amount: number, initial: boolean, collectionMode = false, decades: string[] = []) => {
     const [artists, setArtists] = useState<Artist[]>([]);
     const [artistLinks, setArtistLinks] = useState<NodeLink[]>([]);
     const [artistsLoading, setArtistsLoading] = useState(false);
@@ -23,25 +23,36 @@ const useArtists = (genreIDs: string[], topAmount = TOP_ARTISTS_TO_FETCH, filter
         resetArtistsError();
         if (!initial) {
             setArtistsLoading(true);
-            // console.log(`fetching ${amount} artists...`);
             try {
-                const selectedSize = genreIDs.length;
-                if (selectedSize === 0) {
-                    const response = await axios.get(`${url}/artists/${filter}/${amount}`);
+                if (decades.length > 0) {
+                    const response = await axios.post(`${url}/artists/by-decades`, {
+                        decades,
+                        filter,
+                        amount,
+                        ...(genreIDs.length > 0 && { genres: genreIDs }),
+                    });
                     setArtists(response.data.artists);
                     setArtistLinks(response.data.links);
                     setTotalArtistsInDB(response.data.count);
-                }
-                if (selectedSize > 0) {
-                    const response = await axios.post(`${url}/artists/${filter}/${amount}`, {genres: genreIDs});
-                    const artistCount = response.data.artists.length;
-                    setArtists(response.data.artists);
-                    setArtistLinks(response.data.links);
-                    setTotalArtistsInDB(
-                        response.data.count > amount
-                            ? response.data.count
-                            : artistCount
-                    );
+                } else {
+                    const selectedSize = genreIDs.length;
+                    if (selectedSize === 0) {
+                        const response = await axios.get(`${url}/artists/${filter}/${amount}`);
+                        setArtists(response.data.artists);
+                        setArtistLinks(response.data.links);
+                        setTotalArtistsInDB(response.data.count);
+                    }
+                    if (selectedSize > 0) {
+                        const response = await axios.post(`${url}/artists/${filter}/${amount}`, {genres: genreIDs});
+                        const artistCount = response.data.artists.length;
+                        setArtists(response.data.artists);
+                        setArtistLinks(response.data.links);
+                        setTotalArtistsInDB(
+                            response.data.count > amount
+                                ? response.data.count
+                                : artistCount
+                        );
+                    }
                 }
             } catch (err) {
                 if (err instanceof AxiosError) {
@@ -91,7 +102,7 @@ const useArtists = (genreIDs: string[], topAmount = TOP_ARTISTS_TO_FETCH, filter
         if (!collectionMode) {
             fetchArtists();
         }
-    }, [genreIDs, filter, initial, collectionMode]);
+    }, [genreIDs, filter, initial, collectionMode, decades]);
 
     // Only refetch if change in amount is more than current amount of artists
     useEffect(() => {


### PR DESCRIPTION
🚨 **DEPENDS ON:** https://github.com/b-price/rhizome-server/pull/6

## Changes
- Wired `selectedDecades` into `useArtists` so selecting a decade triggers a refetch via the new endpoint
- Added DecadesFilter to collection mode. Filters the loaded collection client-side using the same active-during logic
- Added a `selectedDecadeIds` prop to `DecadesFilter` for controlled usage in collection mode
- Refactored `DecadesFilter` to fire the change callback directly in `toggleDecade`/`clearAll` rather than via a `useEffect`