### PR TITLE
Bug/graph renders with nodes but no links

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -777,7 +777,7 @@ function App() {
   const clusteringGenerationRef = useRef(0);
 
   useEffect(() => {
-    if ((graph !== 'artists' && graph !== 'similarArtists') || !currentArtists.length) {
+    if (graph !== 'artists' || !currentArtists.length) {
       setArtistClusters(null);
       return;
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -786,6 +786,10 @@ function App() {
       clearTimeout(clusteringTimeoutRef.current);
     }
 
+    // Reset clusters so the graph hides while recomputing — prevents showing nodes without
+    // edges if artists load before links (race condition on first load).
+    setArtistClusters(null);
+
     setClusteringInProgress(true);
 
     // Debounce clustering computation and run it async

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -774,6 +774,7 @@ function App() {
   const [artistClusters, setArtistClusters] = useState<ClusterResult | null>(null);
   const [clusteringInProgress, setClusteringInProgress] = useState(false);
   const clusteringTimeoutRef = useRef<any | null>(null);
+  const clusteringGenerationRef = useRef(0);
 
   useEffect(() => {
     if ((graph !== 'artists' && graph !== 'similarArtists') || !currentArtists.length) {
@@ -792,6 +793,10 @@ function App() {
 
     setClusteringInProgress(true);
 
+    // Increment generation so any in-flight requestIdleCallback from a previous run is
+    // treated as stale and discarded (clearTimeout only cancels the debounce, not the idle callback).
+    const generation = ++clusteringGenerationRef.current;
+
     // Debounce clustering computation and run it async
     clusteringTimeoutRef.current = setTimeout(() => {
       // Use requestIdleCallback if available, otherwise setTimeout with delay
@@ -804,6 +809,7 @@ function App() {
       };
 
       scheduleClustering(() => {
+        if (clusteringGenerationRef.current !== generation) return;
         try {
           const isDark = resolvedTheme === 'dark';
           const engine = new ClusteringEngine(currentArtists, currentArtistLinks, isDark);


### PR DESCRIPTION
## Changes
- Fix: artist graph no longer flashes nodes without edges on first load or when switching views — `requestIdleCallback` was not cancelable via `clearTimeout`, so stale idle callbacks fired after new data arrived and prematurely enabled the `show` guard with empty/wrong links; fixed with a generation counter that discards orphaned callbacks
- Fix: `artistClusters` now resets to `null` at the start of each clustering run so the loading spinner stays visible until clustering completes with the current data
- Fix: similar artist graph no longer renders twice — clustering was running for `similarArtists` even though that view ignores the result; eliminated the wasted computation and the re-render it caused
