### PR TITLE
update similar artists with background fetch + use proper fetch by name endpoint

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -301,6 +301,7 @@ function App() {
     similarArtists,
     fetchSimilarArtists,
     prefetchSimilarImages,
+    fetchArtistByName,
   } = useArtists(artistQueryGenreIDs, TOP_ARTISTS_TO_FETCH, artistNodeLimitType, artistNodeCount, isBeforeArtistLoad, collectionMode);
 
   // Fetch top artists for the currently displayed genre info or the active filter
@@ -1558,13 +1559,14 @@ function App() {
     if (artist) {
       onArtistNodeClick(artist);
     } else {
-      const fetched = await fetchArtistBySearch(name);
-      if (fetched) {
-        setSelectedArtist(undefined);
-        setArtistInfoToShow(fetched);
-        setShowArtistCard(true);
-        addRecentSelection(fetched);
-        updateUrl({ type: 'artist', id: fetched.id, name: fetched.name });
+      const cachedArtist = artistObjectCache.current.get(name);
+      if (cachedArtist) {
+        onArtistNodeClick(cachedArtist);
+      } else {
+        const fetched = await fetchArtistByName(name);
+        if (fetched) {
+          onArtistNodeClick(fetched);
+        }
       }
     }
   }

--- a/src/hooks/useArtists.tsx
+++ b/src/hooks/useArtists.tsx
@@ -169,6 +169,7 @@ const useArtists = (genreIDs: string[], topAmount = TOP_ARTISTS_TO_FETCH, filter
         }
     }
 
+    // Don't use this unless you want very fuzzy results
     const fetchArtistBySearch = async (query: string): Promise<Artist | undefined> => {
         try {
             const response = await axios.get(`${url}/search/${query}`);
@@ -177,6 +178,18 @@ const useArtists = (genreIDs: string[], topAmount = TOP_ARTISTS_TO_FETCH, filter
             return results.find((r): r is Artist => 'listeners' in r);
         } catch {
             return undefined;
+        }
+    }
+
+    const fetchArtistByName = async (name: string): Promise<Artist | undefined> => {
+        resetArtistsError();
+        try {
+            const response = await axios.get(`${url}/artists/fetch/name/${name}`);
+            return response.data;
+        } catch (err) {
+            if (err instanceof AxiosError) {
+                setArtistsError(err);
+            }
         }
     }
 
@@ -197,6 +210,7 @@ const useArtists = (genreIDs: string[], topAmount = TOP_ARTISTS_TO_FETCH, filter
     const prefetchSimilarImages = async (artist: Artist): Promise<Artist[]> => {
         try {
             const response = await axios.get(`${url}/artists/fetch/similar/${artist.id}`);
+            setSimilarArtists([artist, ...response.data]);
             return [artist, ...response.data] as Artist[];
         } catch {
             return [];
@@ -231,6 +245,7 @@ const useArtists = (genreIDs: string[], topAmount = TOP_ARTISTS_TO_FETCH, filter
         similarArtists,
         fetchSimilarArtists,
         prefetchSimilarImages,
+        fetchArtistByName,
     };
 }
 


### PR DESCRIPTION
When trying to click on a similar artist from the artist info panel: 
The prefetching of images gets the proper similar artists from the db, so use that to update the artists cache, and try to get the artist from the cache if the artist is not in the current view, then use the endpoint for fetching by name if not found. The search endpoint should probably only be used for search as it's quite "fuzzy" and gives clearly wrong results when we don't have an artist that's in the similar artists.