### PR TITLE
Parent genre clustering

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -809,12 +809,14 @@ function App() {
     assignments: Map<string, string>;
     colors: Map<string, string>;
     names: Map<string, string>;
+    primaryGenreTags: Map<string, string>;
   } => {
     const assignments = new Map<string, string>();
     const colors = new Map<string, string>();
     const names = new Map<string, string>();
+    const primaryGenreTags = new Map<string, string>();
 
-    if (!currentArtists.length || !genres.length) return { assignments, colors, names };
+    if (!currentArtists.length || !genres.length) return { assignments, colors, names, primaryGenreTags };
 
     const isDark = resolvedTheme === 'dark';
     const genreById = new Map(genres.map(g => [g.id, g]));
@@ -843,6 +845,7 @@ function App() {
           .filter(t => genreByName.has(t.name))
           .sort((a, b) => b.count - a.count);
         if (genreTags.length > 0) {
+          primaryGenreTags.set(artist.id, genreTags[0].name);
           const tagGenre = genreByName.get(genreTags[0].name);
           if (tagGenre?.rootGenres?.[0]) rootGenreId = tagGenre.rootGenres[0];
         }
@@ -872,7 +875,7 @@ function App() {
     colors.set('unknown', isDark ? DEFAULT_DARK_NODE_COLOR : DEFAULT_LIGHT_NODE_COLOR);
     names.set('unknown', 'Unknown Genre');
 
-    return { assignments, colors, names };
+    return { assignments, colors, names, primaryGenreTags };
   }, [currentArtists, genres, genreRoots, resolvedTheme]);
 
   // Compute artist clusters using selected clustering method
@@ -926,6 +929,7 @@ function App() {
               genreAssignments: artistGenreAssignments.assignments,
               genreColors: artistGenreAssignments.colors,
               genreNames: artistGenreAssignments.names,
+              artistPrimaryGenreTags: artistGenreAssignments.primaryGenreTags,
             }),
           });
           setArtistClusters(result);

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -808,6 +808,61 @@ const Graph = forwardRef(function GraphInner<
     }
   }, [dataSignature, dagMode, preparedData, selectedId, show, radialLayout]);
 
+  // Cluster centroid force: pulls every node toward its cluster's live centroid each simulation tick.
+  // Uses the same nodeIds that determine cluster color, so the force is always consistent with the overlay.
+  // Runs in a separate effect so it can update independently of the main data signature.
+  useEffect(() => {
+    if (!show || !fgRef.current) return;
+    const fg = fgRef.current;
+
+    if (clusterOverlays && clusterOverlays.length > 0 && !radialLayout?.enabled) {
+      const nodeToClusterId = new Map<string, string>();
+      clusterOverlays.forEach(overlay => {
+        overlay.nodeIds.forEach(nodeId => nodeToClusterId.set(nodeId, overlay.id));
+      });
+
+      const CLUSTER_STRENGTH = 0.12;
+      const simNodes: any[] = [];
+
+      const centroidForce = Object.assign(
+        function(alpha: number) {
+          const centroids = new Map<string, { x: number; y: number; count: number }>();
+          simNodes.forEach(node => {
+            const cid = nodeToClusterId.get(node.id);
+            if (cid === undefined) return;
+            let c = centroids.get(cid);
+            if (!c) { c = { x: 0, y: 0, count: 0 }; centroids.set(cid, c); }
+            c.x += node.x ?? 0;
+            c.y += node.y ?? 0;
+            c.count++;
+          });
+          centroids.forEach(c => { c.x /= c.count; c.y /= c.count; });
+
+          simNodes.forEach(node => {
+            const cid = nodeToClusterId.get(node.id);
+            if (cid === undefined) return;
+            const centroid = centroids.get(cid);
+            if (!centroid) return;
+            node.vx = (node.vx ?? 0) - (node.x - centroid.x) * alpha * CLUSTER_STRENGTH;
+            node.vy = (node.vy ?? 0) - (node.y - centroid.y) * alpha * CLUSTER_STRENGTH;
+          });
+        },
+        {
+          initialize(nodes: any[]) {
+            simNodes.length = 0;
+            simNodes.push(...nodes);
+          },
+        }
+      );
+
+      fg.d3Force('cluster-centroid', centroidForce);
+    } else {
+      fg.d3Force('cluster-centroid', null);
+    }
+
+    fg.d3ReheatSimulation?.();
+  }, [clusterOverlays, radialLayout, show]);
+
   useEffect(() => {
     if (!autoFocus || !show || !selectedId || !fgRef.current) return;
     const node = preparedData.nodes.find((n) => n.id === selectedId);

--- a/src/lib/ClusteringEngine.ts
+++ b/src/lib/ClusteringEngine.ts
@@ -107,8 +107,7 @@ export class ClusteringEngine {
         return this.clusterByGenre(
           options.genreAssignments ?? new Map(),
           options.genreColors ?? new Map(),
-          options.genreNames,
-          minSimilarity
+          options.genreNames
         );
       default:
         return this.clusterByLouvain(options.resolution || 1.0);
@@ -445,12 +444,13 @@ export class ClusteringEngine {
     };
   }
 
-  // 5. GENRE CLUSTERING - Deterministic assignment by root genre + tag-vector intra-genre links
+  // 5. GENRE CLUSTERING - Deterministic assignment by root genre + parent-genre-primary link generation
+  // Primary bond: shared parent genre (all cluster-mates get a guaranteed baseline attraction)
+  // Secondary factor: tag similarity boosts link weight for more similar artists
   private clusterByGenre(
     genreAssignments: Map<string, string>,
     genreColors: Map<string, string>,
     genreNames?: Map<string, string>,
-    minSimilarity: number = 0.9
   ): ClusterResult {
     const clusters = new Map<string, Cluster>();
     const artistToCluster = new Map<string, string>();
@@ -471,23 +471,44 @@ export class ClusteringEngine {
       artistToCluster.set(artist.id, clusterId);
     });
 
-    // Reuse tag-vector KNN similarity from byTags for intra-genre link generation.
-    // mutualOnly=false gives more edges within the (smaller) genre subsets without bees-nest density.
-    const tagSimilarities = this.calculateTagSimilarities(10, minSimilarity, false);
+    // Build tag vectors once for the whole artist set
+    const vectors = this.buildTagVectors();
 
-    // Filter to intra-cluster links
+    // For each cluster, connect each artist to its K nearest cluster-mates.
+    // Weight = BASE_WEIGHT + (1 - BASE_WEIGHT) * tagSimilarity
+    // BASE_WEIGHT guarantees every cluster-mate pair has attraction even with zero shared tags,
+    // so same-parent-genre nodes always pull together regardless of tag overlap.
+    const BASE_WEIGHT = 0.2;
+    const K_INTRA = 8;
+    const seen = new Set<string>();
     const intraClusterLinks: Array<{ source: string; target: string; weight: number }> = [];
-    tagSimilarities.forEach((weight, key) => {
-      const [source, target] = key.split('|');
-      const sc = artistToCluster.get(source);
-      const tc = artistToCluster.get(target);
 
-      if (sc && tc && sc === tc) {
-        intraClusterLinks.push({ source, target, weight });
-      }
+    clusters.forEach((cluster) => {
+      const ids = cluster.artistIds;
+      if (ids.length <= 1) return;
+
+      ids.forEach((artistId) => {
+        const vecA = vectors.get(artistId);
+        const scores: Array<{ id: string; weight: number }> = [];
+
+        ids.forEach((otherId) => {
+          if (otherId === artistId) return;
+          const vecB = vectors.get(otherId);
+          const tagSim = vecA && vecB ? this.cosineSimilarity(vecA, vecB) : 0;
+          scores.push({ id: otherId, weight: BASE_WEIGHT + (1 - BASE_WEIGHT) * tagSim });
+        });
+
+        scores.sort((a, b) => b.weight - a.weight);
+        scores.slice(0, K_INTRA).forEach(({ id, weight }) => {
+          const key = artistId < id ? `${artistId}|${id}` : `${id}|${artistId}`;
+          if (!seen.has(key)) {
+            seen.add(key);
+            intraClusterLinks.push({ source: artistId, target: id, weight });
+          }
+        });
+      });
     });
 
-    // Cap node degree to reduce density in large clusters
     const links = this.capNodeDegree(intraClusterLinks, 10);
 
     return { method: 'genre', clusters, artistToCluster, links, stats: this.calculateStats(clusters) };

--- a/src/lib/ClusteringEngine.ts
+++ b/src/lib/ClusteringEngine.ts
@@ -43,9 +43,10 @@ export interface ClusteringOptions {
   kNeighbors?: number;  // Number of nearest neighbors to keep (default: 20)
   minSimilarity?: number;  // Minimum similarity threshold (0-1, default: 0.1)
   // Only required when method === 'genre'
-  genreAssignments?: Map<string, string>;  // artistId -> rootGenreId
-  genreColors?: Map<string, string>;       // rootGenreId -> hex color
-  genreNames?: Map<string, string>;        // rootGenreId -> display name
+  genreAssignments?: Map<string, string>;       // artistId -> rootGenreId
+  genreColors?: Map<string, string>;            // rootGenreId -> hex color
+  genreNames?: Map<string, string>;             // rootGenreId -> display name
+  artistPrimaryGenreTags?: Map<string, string>; // artistId -> top genre tag name (e.g. "black metal")
 }
 
 export class ClusteringEngine {
@@ -107,7 +108,8 @@ export class ClusteringEngine {
         return this.clusterByGenre(
           options.genreAssignments ?? new Map(),
           options.genreColors ?? new Map(),
-          options.genreNames
+          options.genreNames,
+          options.artistPrimaryGenreTags
         );
       default:
         return this.clusterByLouvain(options.resolution || 1.0);
@@ -444,13 +446,16 @@ export class ClusteringEngine {
     };
   }
 
-  // 5. GENRE CLUSTERING - Deterministic assignment by root genre + parent-genre-primary link generation
-  // Primary bond: shared parent genre (all cluster-mates get a guaranteed baseline attraction)
-  // Secondary factor: tag similarity boosts link weight for more similar artists
+  // 5. GENRE CLUSTERING
+  // Bond hierarchy:
+  //   1. Shared primary genre tag (e.g. "black metal") → guaranteed link regardless of cosine sim
+  //   2. Shared parent genre (same cluster) → KNN backbone with BASE_WEIGHT floor
+  //   3. Full tag cosine similarity → boosts weight within both groups
   private clusterByGenre(
     genreAssignments: Map<string, string>,
     genreColors: Map<string, string>,
     genreNames?: Map<string, string>,
+    artistPrimaryGenreTags?: Map<string, string>,
   ): ClusterResult {
     const clusters = new Map<string, Cluster>();
     const artistToCluster = new Map<string, string>();
@@ -471,22 +476,53 @@ export class ClusteringEngine {
       artistToCluster.set(artist.id, clusterId);
     });
 
-    // Build tag vectors once for the whole artist set
     const vectors = this.buildTagVectors();
-
-    // For each cluster, connect each artist to its K nearest cluster-mates.
-    // Weight = BASE_WEIGHT + (1 - BASE_WEIGHT) * tagSimilarity
-    // BASE_WEIGHT guarantees every cluster-mate pair has attraction even with zero shared tags,
-    // so same-parent-genre nodes always pull together regardless of tag overlap.
     const BASE_WEIGHT = 0.2;
     const K_INTRA = 8;
     const seen = new Set<string>();
     const intraClusterLinks: Array<{ source: string; target: string; weight: number }> = [];
 
+    const addLink = (a: string, b: string, weight: number) => {
+      const key = a < b ? `${a}|${b}` : `${b}|${a}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        intraClusterLinks.push({ source: a, target: b, weight });
+      }
+    };
+
     clusters.forEach((cluster) => {
       const ids = cluster.artistIds;
       if (ids.length <= 1) return;
 
+      // --- Pass 1: guarantee links for artists sharing the same primary genre tag ---
+      // TF-IDF cosine sim can rank artists with the same specific genre tag (e.g. "black metal")
+      // below K_INTRA if their broader tag profiles diverge. This pass fixes that.
+      if (artistPrimaryGenreTags) {
+        const byTag = new Map<string, string[]>();
+        ids.forEach(id => {
+          const tag = artistPrimaryGenreTags.get(id);
+          if (tag) {
+            if (!byTag.has(tag)) byTag.set(tag, []);
+            byTag.get(tag)!.push(id);
+          }
+        });
+
+        byTag.forEach(tagGroup => {
+          if (tagGroup.length <= 1) return;
+          tagGroup.forEach(a => {
+            tagGroup.forEach(b => {
+              if (a >= b) return;
+              const vecA = vectors.get(a);
+              const vecB = vectors.get(b);
+              const tagSim = vecA && vecB ? this.cosineSimilarity(vecA, vecB) : 0;
+              addLink(a, b, BASE_WEIGHT + (1 - BASE_WEIGHT) * tagSim);
+            });
+          });
+        });
+      }
+
+      // --- Pass 2: KNN backbone — connect each artist to its K nearest cluster-mates ---
+      // BASE_WEIGHT floor ensures same-parent-genre nodes always attract even with zero shared tags.
       ids.forEach((artistId) => {
         const vecA = vectors.get(artistId);
         const scores: Array<{ id: string; weight: number }> = [];
@@ -499,13 +535,7 @@ export class ClusteringEngine {
         });
 
         scores.sort((a, b) => b.weight - a.weight);
-        scores.slice(0, K_INTRA).forEach(({ id, weight }) => {
-          const key = artistId < id ? `${artistId}|${id}` : `${id}|${artistId}`;
-          if (!seen.has(key)) {
-            seen.add(key);
-            intraClusterLinks.push({ source: artistId, target: id, weight });
-          }
-        });
+        scores.slice(0, K_INTRA).forEach(({ id, weight }) => addLink(artistId, id, weight));
       });
     });
 

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -26,7 +26,7 @@ Artist[] + NodeLink[]
 - `similarArtists`: Louvain community detection on the existing similar-artist network.
 - `hybrid`: weighted blend of tag-vector similarity + network links, with an optional location penalty. (Currently unused in the UI — replaced by `genre` for collection mode.)
 - `popularity`: percentile-based listener tiers (used for radial layout in the UI).
-- `genre`: deterministic assignment by root genre (Rock, Electronic, etc.). Requires `genreAssignments`, `genreColors`, and `genreNames` in `ClusteringOptions`. Intra-cluster links are generated from KNN tag-vector similarity (reuses hybrid's `calculateTagSimilarities`). Only surfaced in collection mode.
+- `genre`: deterministic assignment by root genre (Rock, Electronic, etc.). Requires `genreAssignments`, `genreColors`, and `genreNames` in `ClusteringOptions`. Intra-cluster links use a two-factor model: shared parent genre is the primary bond (every cluster-mate gets a guaranteed `BASE_WEIGHT=0.2` attraction so same-parent nodes always pull together), and tag-vector cosine similarity boosts the weight up to 1.0 as a secondary factor. Each artist connects to its top-8 cluster-mates by this combined score. Only surfaced in collection mode.
 
 `popularity` returns `tierData` for concentric-ring layouts. `genre` requires pre-computed genre maps passed from App.tsx via `ClusteringOptions`.
 


### PR DESCRIPTION
## Changes
- Changed "cluster by genre" link generation in `ClusteringEngine.clusterByGenre` to use parent genre as the primary bond: every artist in the same root-genre cluster now connects to its K nearest cluster-mates with a guaranteed minimum weight (`BASE_WEIGHT=0.2`), ensuring same-parent-genre nodes are always attracted by the force simulation even when they share no tag overlap. Tag cosine similarity boosts the weight as a secondary factor (up to 1.0). Previously, links were only created between artists above a 0.9 tag-similarity threshold, leaving same-color nodes scattered across the graph and causing cluster overlays to overlap wildly.
- Added a D3 cluster centroid force to `Graph.tsx` that pulls every node toward its cluster's live centroid each simulation tick, using the same `nodeIds` that drive the color overlay. This makes same-parent-genre nodes converge spatially rather than relying solely on link-based attraction. The force is disabled when `radialLayout` is active so it does not interfere with popularity clustering.
