### PR TITLE
fix collection artists total

### DIFF
--- a/src/hooks/useArtists.tsx
+++ b/src/hooks/useArtists.tsx
@@ -156,7 +156,7 @@ const useArtists = (genreIDs: string[], topAmount = TOP_ARTISTS_TO_FETCH, filter
             const response = await axios.post(`${url}/artists/multiple`, { artists: artists.slice(0, limit) });
             setArtists(response.data.artists);
             setArtistLinks(response.data.links);
-            setTotalArtistsInDB(artists.length);
+            setTotalArtistsInDB(response.data.artists.length);
         } catch (err) {
             if (err instanceof AxiosError) {
                 setArtistsError(err);


### PR DESCRIPTION
This fixes the display for the amount of artists in a user's collection. It now shows the artists we have data for in our DB (so the amount of nodes) rather than the amount of artists the user has in their last.fm account.