### PR TITLE
Overlay on tags

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -113,7 +113,7 @@ function SidebarLogoTrigger() {
 
 
 function App() {
-  type GraphHandle = { zoomIn: () => void; zoomOut: () => void; zoomTo: (k: number, ms?: number) => void; resetView: (k: number, ms?: number) => void; getZoom: () => number; getCanvas: () => HTMLCanvasElement | null }
+  type GraphHandle = { zoomIn: () => void; zoomOut: () => void; zoomTo: (k: number, ms?: number) => void; resetView: (k: number, ms?: number) => void; getZoom: () => number; getCanvas: () => HTMLCanvasElement | null; setAiClusterLabels: (labels: Map<string, string>) => void }
   const genresGraphRef = useRef<GraphHandle | null>(null);
   const artistsGraphRef = useRef<GraphHandle | null>(null);
   const [viewport, setViewport] = useState<{ width: number; height: number }>({ width: 0, height: 0 });
@@ -862,7 +862,6 @@ function App() {
   // Compute artist clusters using selected clustering method
   // Use async computation for large graphs to avoid blocking UI
   const [artistClusters, setArtistClusters] = useState<ClusterResult | null>(null);
-  const [aiClusterLabels, setAiClusterLabels] = useState<Map<string, string> | null>(null);
   const [clusteringInProgress, setClusteringInProgress] = useState(false);
   const clusteringTimeoutRef = useRef<any | null>(null);
   const clusteringGenerationRef = useRef(0);
@@ -923,21 +922,18 @@ function App() {
               artistPrimaryGenreTags: artistGenreAssignments.primaryGenreTags,
             }),
           });
-          setAiClusterLabels(null); // null = loading; overlay animates until this resolves
           setArtistClusters(result);
 
           if (artistClusterMethod === 'byTags') {
             labelClustersWithAI(result.clusters, currentArtists)
               .then(labels => {
                 if (clusteringGenerationRef.current !== generation) return;
-                setAiClusterLabels(labels);
+                artistsGraphRef.current?.setAiClusterLabels(labels);
               })
               .catch(() => {
                 if (clusteringGenerationRef.current !== generation) return;
-                setAiClusterLabels(new Map()); // empty map = done, keep tag-based fallback
+                artistsGraphRef.current?.setAiClusterLabels(new Map());
               });
-          } else {
-            setAiClusterLabels(new Map()); // not byTags, no AI labels needed
           }
         } catch (error) {
           console.error('Artist clustering failed:', error);
@@ -1020,21 +1016,20 @@ function App() {
       artistClusterMethod = exploreArtistClusterMethod;
     }
     if (!artistClusters || !['genre', 'byTags', 'popularity'].includes(artistClusterMethod) || !showClusterOverlay) return undefined;
-    const isAiLoading = artistClusterMethod === 'byTags' && aiClusterLabels === null;
     const overlays: ClusterOverlay[] = [];
     for (const cluster of artistClusters.clusters.values()) {
       if (cluster.artistIds.length === 0) continue;
       overlays.push({
         id: cluster.id,
-        name: aiClusterLabels?.get(cluster.id) ?? cluster.name,
+        name: cluster.name,
         color: cluster.color,
         nodeIds: new Set(cluster.artistIds),
-        isLoading: isAiLoading,
+        isLoading: artistClusterMethod === 'byTags',
         loadingTags: cluster.tags,
       });
     }
     return overlays.length > 0 ? overlays : undefined;
-  }, [artistClusters, aiClusterLabels, graph, collectionMode, collectionArtistClusterMethod, exploreArtistClusterMethod, similarArtistClusterMethod, showClusterOverlay]);
+  }, [artistClusters, graph, collectionMode, collectionArtistClusterMethod, exploreArtistClusterMethod, similarArtistClusterMethod, showClusterOverlay]);
 
   // Compute radial layout from cluster tier data for popularity stratification
   const artistRadialLayout = useMemo(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ import {
   isOnPage,
 } from "@/lib/utils";
 import { ClusteringEngine, ClusterResult } from '@/lib/ClusteringEngine';
+import { labelClustersWithAI } from '@/lib/clusterLabeling';
 import { getPriorityLabelIds } from '@/lib/CentralityMetrics';
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import ClusteringPanel from "@/components/ClusteringPanel";
@@ -922,6 +923,21 @@ function App() {
             }),
           });
           setArtistClusters(result);
+
+          if (artistClusterMethod === 'byTags') {
+            labelClustersWithAI(result.clusters, currentArtists).then(labels => {
+              if (clusteringGenerationRef.current !== generation) return;
+              setArtistClusters(prev => {
+                if (!prev || prev.method !== 'byTags') return prev;
+                const newClusters = new Map(prev.clusters);
+                labels.forEach((label, id) => {
+                  const cluster = newClusters.get(id);
+                  if (cluster) newClusters.set(id, { ...cluster, name: label });
+                });
+                return { ...prev, clusters: newClusters };
+              });
+            }).catch(() => { /* keep tag-based fallback names */ });
+          }
         } catch (error) {
           console.error('Artist clustering failed:', error);
           toast.error('Failed to compute artist clusters');
@@ -1002,7 +1018,7 @@ function App() {
     } else {
       artistClusterMethod = exploreArtistClusterMethod;
     }
-    if (!artistClusters || !['genre', 'popularity'].includes(artistClusterMethod) || !showClusterOverlay) return undefined;
+    if (!artistClusters || !['genre', 'byTags', 'popularity'].includes(artistClusterMethod) || !showClusterOverlay) return undefined;
     const overlays: ClusterOverlay[] = [];
     for (const cluster of artistClusters.clusters.values()) {
       if (cluster.artistIds.length === 0) continue;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -862,6 +862,7 @@ function App() {
   // Compute artist clusters using selected clustering method
   // Use async computation for large graphs to avoid blocking UI
   const [artistClusters, setArtistClusters] = useState<ClusterResult | null>(null);
+  const [aiClusterLabels, setAiClusterLabels] = useState<Map<string, string> | null>(null);
   const [clusteringInProgress, setClusteringInProgress] = useState(false);
   const clusteringTimeoutRef = useRef<any | null>(null);
   const clusteringGenerationRef = useRef(0);
@@ -922,21 +923,21 @@ function App() {
               artistPrimaryGenreTags: artistGenreAssignments.primaryGenreTags,
             }),
           });
+          setAiClusterLabels(null); // null = loading; overlay animates until this resolves
           setArtistClusters(result);
 
           if (artistClusterMethod === 'byTags') {
-            labelClustersWithAI(result.clusters, currentArtists).then(labels => {
-              if (clusteringGenerationRef.current !== generation) return;
-              setArtistClusters(prev => {
-                if (!prev || prev.method !== 'byTags') return prev;
-                const newClusters = new Map(prev.clusters);
-                labels.forEach((label, id) => {
-                  const cluster = newClusters.get(id);
-                  if (cluster) newClusters.set(id, { ...cluster, name: label });
-                });
-                return { ...prev, clusters: newClusters };
+            labelClustersWithAI(result.clusters, currentArtists)
+              .then(labels => {
+                if (clusteringGenerationRef.current !== generation) return;
+                setAiClusterLabels(labels);
+              })
+              .catch(() => {
+                if (clusteringGenerationRef.current !== generation) return;
+                setAiClusterLabels(new Map()); // empty map = done, keep tag-based fallback
               });
-            }).catch(() => { /* keep tag-based fallback names */ });
+          } else {
+            setAiClusterLabels(new Map()); // not byTags, no AI labels needed
           }
         } catch (error) {
           console.error('Artist clustering failed:', error);
@@ -1019,18 +1020,21 @@ function App() {
       artistClusterMethod = exploreArtistClusterMethod;
     }
     if (!artistClusters || !['genre', 'byTags', 'popularity'].includes(artistClusterMethod) || !showClusterOverlay) return undefined;
+    const isAiLoading = artistClusterMethod === 'byTags' && aiClusterLabels === null;
     const overlays: ClusterOverlay[] = [];
     for (const cluster of artistClusters.clusters.values()) {
       if (cluster.artistIds.length === 0) continue;
       overlays.push({
         id: cluster.id,
-        name: cluster.name,
+        name: aiClusterLabels?.get(cluster.id) ?? cluster.name,
         color: cluster.color,
         nodeIds: new Set(cluster.artistIds),
+        isLoading: isAiLoading,
+        loadingTags: cluster.tags,
       });
     }
     return overlays.length > 0 ? overlays : undefined;
-  }, [artistClusters, graph, collectionMode, collectionArtistClusterMethod, exploreArtistClusterMethod, similarArtistClusterMethod, showClusterOverlay]);
+  }, [artistClusters, aiClusterLabels, graph, collectionMode, collectionArtistClusterMethod, exploreArtistClusterMethod, similarArtistClusterMethod, showClusterOverlay]);
 
   // Compute radial layout from cluster tier data for popularity stratification
   const artistRadialLayout = useMemo(() => {

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -258,6 +258,7 @@ function drawClusterLabels(
   overlays: ClusterOverlay[],
   nodeMap: Map<string, NodePosEntry>,
   globalScale: number,
+  aiLabels: Map<string, string> | null,
 ): void {
   const fontSize = CLUSTER_LABEL_SCREEN_PX / globalScale;
   const now = Date.now();
@@ -283,7 +284,9 @@ function drawClusterLabels(
     ctx.shadowOffsetX = 0;
     ctx.shadowOffsetY = 0;
 
-    if (overlay.isLoading && overlay.loadingTags?.length) {
+    const isAnimating = overlay.isLoading && aiLabels === null;
+
+    if (isAnimating && overlay.loadingTags?.length) {
       const tagIndex = Math.floor(now / 1000) % overlay.loadingTags.length;
       const dotCount = (Math.floor(now / 333) % 3) + 1;
       const tagText = overlay.loadingTags[tagIndex];
@@ -303,6 +306,7 @@ function drawClusterLabels(
       ctx.fillStyle = hexToRgba(overlay.color, 0.25);
       ctx.fillText('.'.repeat(dotCount), leftEdge + tagWidth, labelY);
     } else {
+      const finalName = (overlay.isLoading ? aiLabels?.get(overlay.id) : undefined) ?? overlay.name;
       ctx.font = `600 ${fontSize}px Inter, system-ui, sans-serif`;
       ctx.textAlign = 'center';
       try {
@@ -310,7 +314,7 @@ function drawClusterLabels(
       } catch {
         ctx.fillStyle = overlay.color;
       }
-      ctx.fillText(overlay.name, cx, labelY);
+      ctx.fillText(finalName, cx, labelY);
     }
 
     ctx.restore();
@@ -431,6 +435,8 @@ const Graph = forwardRef(function GraphInner<
   const fgRef = useRef<ForceGraphMethods<PreparedNode<T>, L> | undefined>(undefined);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const zoomRef = useRef<number>(1);
+  const aiClusterLabelsRef = useRef<Map<string, string> | null>(null);
+  const loadingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const showNodesRef = useRef<boolean>(showNodes);
   const showLinksRef = useRef<boolean>(showLinks);
   const clusterOverlaysRef = useRef<ClusterOverlay[] | undefined>(undefined);
@@ -464,21 +470,33 @@ const Graph = forwardRef(function GraphInner<
 
   useEffect(() => {
     clusterOverlaysRef.current = clusterOverlays;
-    // autoPauseRedraw stops the canvas when the sim is idle, so poke it to
-    // repaint after the overlay data changes (on/off toggle, data update, etc.)
     fgRef.current?.resumeAnimation?.();
-  }, [clusterOverlays]);
 
-  // While any overlay is in loading state, poke the canvas every 300ms so the
-  // tag-cycling and dot animation actually render (autoPauseRedraw would otherwise
-  // freeze the canvas as soon as the sim settles).
-  useEffect(() => {
-    const hasLoading = clusterOverlays?.some(o => o.isLoading);
-    if (!hasLoading) return;
-    const id = setInterval(() => {
-      fgRef.current?.resumeAnimation?.();
-    }, 300);
-    return () => clearInterval(id);
+    if (clusterOverlays?.some(o => o.isLoading)) {
+      // New loading overlays arrived — reset AI labels and start repaint interval
+      aiClusterLabelsRef.current = null;
+      if (loadingIntervalRef.current) clearInterval(loadingIntervalRef.current);
+      loadingIntervalRef.current = setInterval(() => {
+        if (aiClusterLabelsRef.current !== null) {
+          clearInterval(loadingIntervalRef.current!);
+          loadingIntervalRef.current = null;
+          return;
+        }
+        fgRef.current?.resumeAnimation?.();
+      }, 300);
+    } else {
+      if (loadingIntervalRef.current) {
+        clearInterval(loadingIntervalRef.current);
+        loadingIntervalRef.current = null;
+      }
+    }
+
+    return () => {
+      if (loadingIntervalRef.current) {
+        clearInterval(loadingIntervalRef.current);
+        loadingIntervalRef.current = null;
+      }
+    };
   }, [clusterOverlays]);
 
   // Convert display control values to usable ranges (all centered at 50 = 1.0x)
@@ -563,6 +581,14 @@ const Graph = forwardRef(function GraphInner<
           return canvas as HTMLCanvasElement | null;
         }
         return null;
+      },
+      setAiClusterLabels: (labels: Map<string, string>) => {
+        aiClusterLabelsRef.current = labels;
+        if (loadingIntervalRef.current) {
+          clearInterval(loadingIntervalRef.current);
+          loadingIntervalRef.current = null;
+        }
+        fgRef.current?.resumeAnimation?.();
       },
     }),
     [],
@@ -1018,7 +1044,7 @@ const Graph = forwardRef(function GraphInner<
     if (!nodes?.length) return;
     const nodeMap = new Map<string, NodePosEntry>();
     for (const n of nodes) nodeMap.set(n.id, n);
-    drawClusterLabels(ctx, overlays, nodeMap, globalScale);
+    drawClusterLabels(ctx, overlays, nodeMap, globalScale, aiClusterLabelsRef.current);
   }, []);
 
   return (

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -93,6 +93,8 @@ export interface ClusterOverlay {
   name: string;
   color: string;
   nodeIds: Set<string>;
+  isLoading?: boolean;
+  loadingTags?: string[];
 }
 
 // --- Cluster hull drawing helpers ---
@@ -258,6 +260,7 @@ function drawClusterLabels(
   globalScale: number,
 ): void {
   const fontSize = CLUSTER_LABEL_SCREEN_PX / globalScale;
+  const now = Date.now();
 
   for (const overlay of overlays) {
     const positions: [number, number][] = [];
@@ -273,15 +276,31 @@ function drawClusterLabels(
     const minY = Math.min(...positions.map(p => p[1]));
     const labelY = minY - CLUSTER_HULL_PADDING - fontSize * 0.7;
 
+    let displayName: string;
+    let labelAlpha: number;
+    let fontWeight: string;
+
+    if (overlay.isLoading && overlay.loadingTags?.length) {
+      const tagIndex = Math.floor(now / 1000) % overlay.loadingTags.length;
+      const dotCount = (Math.floor(now / 333) % 3) + 1;
+      displayName = `${overlay.loadingTags[tagIndex]}${'.'.repeat(dotCount)}`;
+      labelAlpha = 0.4;
+      fontWeight = '400';
+    } else {
+      displayName = overlay.name;
+      labelAlpha = 0.85;
+      fontWeight = '600';
+    }
+
     let labelColor: string;
     try {
-      labelColor = hexToRgba(overlay.color, 0.85);
+      labelColor = hexToRgba(overlay.color, labelAlpha);
     } catch {
       labelColor = overlay.color;
     }
 
     ctx.save();
-    ctx.font = `600 ${fontSize}px Inter, system-ui, sans-serif`;
+    ctx.font = `${fontWeight} ${fontSize}px Inter, system-ui, sans-serif`;
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
     ctx.fillStyle = labelColor;
@@ -289,7 +308,7 @@ function drawClusterLabels(
     ctx.shadowBlur = 4;
     ctx.shadowOffsetX = 0;
     ctx.shadowOffsetY = 0;
-    ctx.fillText(overlay.name, cx, labelY);
+    ctx.fillText(displayName, cx, labelY);
     ctx.restore();
   }
 }
@@ -444,6 +463,18 @@ const Graph = forwardRef(function GraphInner<
     // autoPauseRedraw stops the canvas when the sim is idle, so poke it to
     // repaint after the overlay data changes (on/off toggle, data update, etc.)
     fgRef.current?.resumeAnimation?.();
+  }, [clusterOverlays]);
+
+  // While any overlay is in loading state, poke the canvas every 300ms so the
+  // tag-cycling and dot animation actually render (autoPauseRedraw would otherwise
+  // freeze the canvas as soon as the sim settles).
+  useEffect(() => {
+    const hasLoading = clusterOverlays?.some(o => o.isLoading);
+    if (!hasLoading) return;
+    const id = setInterval(() => {
+      fgRef.current?.resumeAnimation?.();
+    }, 300);
+    return () => clearInterval(id);
   }, [clusterOverlays]);
 
   // Convert display control values to usable ranges (all centered at 50 = 1.0x)

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -276,39 +276,43 @@ function drawClusterLabels(
     const minY = Math.min(...positions.map(p => p[1]));
     const labelY = minY - CLUSTER_HULL_PADDING - fontSize * 0.7;
 
-    let displayName: string;
-    let labelAlpha: number;
-    let fontWeight: string;
-
-    if (overlay.isLoading && overlay.loadingTags?.length) {
-      const tagIndex = Math.floor(now / 1000) % overlay.loadingTags.length;
-      const dotCount = (Math.floor(now / 333) % 3) + 1;
-      displayName = `${overlay.loadingTags[tagIndex]}${'.'.repeat(dotCount)}`;
-      labelAlpha = 0.4;
-      fontWeight = '400';
-    } else {
-      displayName = overlay.name;
-      labelAlpha = 0.85;
-      fontWeight = '600';
-    }
-
-    let labelColor: string;
-    try {
-      labelColor = hexToRgba(overlay.color, labelAlpha);
-    } catch {
-      labelColor = overlay.color;
-    }
-
     ctx.save();
-    ctx.font = `${fontWeight} ${fontSize}px Inter, system-ui, sans-serif`;
-    ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
-    ctx.fillStyle = labelColor;
     ctx.shadowColor = 'rgba(0, 0, 0, 0.8)';
     ctx.shadowBlur = 4;
     ctx.shadowOffsetX = 0;
     ctx.shadowOffsetY = 0;
-    ctx.fillText(displayName, cx, labelY);
+
+    if (overlay.isLoading && overlay.loadingTags?.length) {
+      const tagIndex = Math.floor(now / 1000) % overlay.loadingTags.length;
+      const dotCount = (Math.floor(now / 333) % 3) + 1;
+      const tagText = overlay.loadingTags[tagIndex];
+
+      ctx.font = `400 ${fontSize}px Inter, system-ui, sans-serif`;
+      ctx.textAlign = 'left';
+
+      // Measure max-width string ("tag...") to get a stable center that never
+      // shifts as the dot count animates — same idea as an absolutely-positioned span.
+      const tagWidth = ctx.measureText(tagText).width;
+      const maxDotsWidth = ctx.measureText('...').width;
+      const leftEdge = cx - (tagWidth + maxDotsWidth) / 2;
+
+      ctx.fillStyle = hexToRgba(overlay.color, 0.4);
+      ctx.fillText(tagText, leftEdge, labelY);
+
+      ctx.fillStyle = hexToRgba(overlay.color, 0.25);
+      ctx.fillText('.'.repeat(dotCount), leftEdge + tagWidth, labelY);
+    } else {
+      ctx.font = `600 ${fontSize}px Inter, system-ui, sans-serif`;
+      ctx.textAlign = 'center';
+      try {
+        ctx.fillStyle = hexToRgba(overlay.color, 0.85);
+      } catch {
+        ctx.fillStyle = overlay.color;
+      }
+      ctx.fillText(overlay.name, cx, labelY);
+    }
+
     ctx.restore();
   }
 }

--- a/src/lib/ClusteringEngine.ts
+++ b/src/lib/ClusteringEngine.ts
@@ -30,6 +30,7 @@ export interface Cluster {
   artistIds: string[];
   color: string;
   centroid?: { x: number; y: number }; // For visualization
+  tags?: string[]; // Top listener tags, used for loading animation
 }
 
 export interface ClusteringOptions {
@@ -390,11 +391,12 @@ export class ClusteringEngine {
       result.links = this.capNodeDegree(result.links, 12);
     }
 
-    // Label each cluster with its top shared tags instead of the generic "By Tags N"
+    // Store top tags and set fallback name (used for loading animation and AI label fallback)
     result.clusters.forEach(cluster => {
-      const topTags = this.getTopTagsForArtists(cluster.artistIds, 3);
+      const topTags = this.getTopTagsForArtists(cluster.artistIds, 5);
+      cluster.tags = topTags;
       if (topTags.length > 0) {
-        cluster.name = topTags.join(' · ');
+        cluster.name = topTags.slice(0, 3).join(' · ');
       }
     });
 

--- a/src/lib/ClusteringEngine.ts
+++ b/src/lib/ClusteringEngine.ts
@@ -389,7 +389,33 @@ export class ClusteringEngine {
     if (result.links && result.links.length > 0) {
       result.links = this.capNodeDegree(result.links, 12);
     }
+
+    // Label each cluster with its top shared tags instead of the generic "By Tags N"
+    result.clusters.forEach(cluster => {
+      const topTags = this.getTopTagsForArtists(cluster.artistIds, 3);
+      if (topTags.length > 0) {
+        cluster.name = topTags.join(' · ');
+      }
+    });
+
     return result;
+  }
+
+  private getTopTagsForArtists(artistIds: string[], count: number): string[] {
+    const artistSet = new Set(artistIds);
+    const tagScore = new Map<string, number>();
+
+    this.artists.forEach(artist => {
+      if (!artistSet.has(artist.id)) return;
+      artist.tags?.forEach(tag => {
+        tagScore.set(tag.name, (tagScore.get(tag.name) ?? 0) + tag.count);
+      });
+    });
+
+    return Array.from(tagScore.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, count)
+      .map(([name]) => name);
   }
 
   // 4. POPULARITY CLUSTERING - Dynamic percentile-based popularity tiers

--- a/src/lib/clusterLabeling.ts
+++ b/src/lib/clusterLabeling.ts
@@ -1,0 +1,67 @@
+import type { Artist, Tag } from '@/types';
+import type { Cluster } from './ClusteringEngine';
+
+function topTagsForArtists(artistIds: string[], artists: Artist[], count: number): string[] {
+  const artistSet = new Set(artistIds);
+  const tagScore = new Map<string, number>();
+
+  artists.forEach(artist => {
+    if (!artistSet.has(artist.id)) return;
+    artist.tags?.forEach((tag: Tag) => {
+      tagScore.set(tag.name, (tagScore.get(tag.name) ?? 0) + tag.count);
+    });
+  });
+
+  return Array.from(tagScore.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, count)
+    .map(([name]) => name);
+}
+
+export async function labelClustersWithAI(
+  clusters: Map<string, Cluster>,
+  artists: Artist[]
+): Promise<Map<string, string>> {
+  const apiKey = import.meta.env.VITE_OPENAI_API_KEY;
+  if (!apiKey) throw new Error('No OpenAI API key configured');
+
+  const clusterEntries = Array.from(clusters.entries())
+    .filter(([, c]) => c.artistIds.length > 0)
+    .map(([id, cluster]) => {
+      const tags = topTagsForArtists(cluster.artistIds, artists, 8);
+      return { id, tags };
+    });
+
+  if (clusterEntries.length === 0) return new Map();
+
+  const clusterList = clusterEntries
+    .map(({ id, tags }) => `"${id}": [${tags.join(', ')}]`)
+    .join('\n');
+
+  const prompt = `You are a music genre expert. Each entry below is a cluster of listeners grouped by their most common Last.fm tags. Give each cluster a concise name (1–3 words) that captures the musical subculture or sound scene — not just the genre name, but the vibe or scene if it fits.
+
+Clusters (ID → top listener tags):
+${clusterList}
+
+Return only a JSON object mapping each cluster ID to its label. Example: {"id1": "Thrash Metal", "id2": "Ambient Drone"}`;
+
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: prompt }],
+      response_format: { type: 'json_object' },
+      temperature: 0.2,
+    }),
+  });
+
+  if (!response.ok) throw new Error(`OpenAI API error: ${response.status}`);
+
+  const data = await response.json();
+  const labels: Record<string, string> = JSON.parse(data.choices[0].message.content);
+  return new Map(Object.entries(labels));
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -168,6 +168,7 @@ export interface GraphHandle {
   resetView: (k: number, ms?: number) => void;
   getZoom: () => number;
   getCanvas: () => HTMLCanvasElement | null;
+  setAiClusterLabels: (labels: Map<string, string>) => void;
 }
 
 export interface FindOption {


### PR DESCRIPTION
## Changes
- Restored cluster overlay for "By Tags" mode
- AI-generated cluster labels: after byTags clustering, a single OpenAI (gpt-4o-mini) batch call replaces tag-string labels with concise scene/subculture names (e.g. "Nordic Black Metal"); while loading, overlays animate through the cluster's top tags with cycling dots in muted text, snapping to full-opacity AI names on resolve