### PR TITLE
Improve alpha survey adoption by fixing trigger logic

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -440,7 +440,7 @@ function App() {
     const sessionCount = parseInt(localStorage.getItem('rhizomeSessionCount') || '1');
     if (sessionCount < 2) return false;
     const lastPromptedSession = parseInt(localStorage.getItem('alphaSurveyLastSession') || '0');
-    return lastPromptedSession === 0 || sessionCount >= lastPromptedSession + 2;
+    return lastPromptedSession === 0 || sessionCount >= lastPromptedSession + 3;
   }
 
   function markAlphaSurveyPrompted(): void {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -443,9 +443,15 @@ function App() {
     return lastPromptedSession === 0 || sessionCount >= lastPromptedSession + 3;
   }
 
-  function markAlphaSurveyPrompted(): void {
+  function showAlphaSurveyToast(): void {
     const sessionCount = parseInt(localStorage.getItem('rhizomeSessionCount') || '1');
     localStorage.setItem('alphaSurveyLastSession', sessionCount.toString());
+    const promptCount = parseInt(localStorage.getItem('alphaSurveyPromptCount') || '0') + 1;
+    localStorage.setItem('alphaSurveyPromptCount', promptCount.toString());
+    showNotiToast('alpha-feedback', {
+      onPrimaryAction: () => localStorage.setItem('showAlphaSurvey', 'false'),
+      ...(promptCount >= 3 && { onPermanentDismiss: () => localStorage.setItem('showAlphaSurvey', 'false') }),
+    });
   }
 
   const hoveredArtistData = useMemo(() => {
@@ -471,11 +477,7 @@ function App() {
   useEffect(() => {
     const timer = setTimeout(() => {
       if (shouldShowAlphaSurvey()) {
-        showNotiToast('alpha-feedback', {
-          onPrimaryAction: () => localStorage.setItem('showAlphaSurvey', 'false'),
-          onPermanentDismiss: () => localStorage.setItem('showAlphaSurvey', 'false'),
-        });
-        markAlphaSurveyPrompted();
+        showAlphaSurveyToast();
       }
     }, ALPHA_SURVEY_TIME_MS)
     return () => {
@@ -1455,11 +1457,7 @@ function App() {
     if (!options?.preview) {
       playsRef.current++;
       if (localStorage.getItem('showAlphaSurvey') !== 'false' && playsRef.current >= 2) {
-        showNotiToast('alpha-feedback', {
-          onPrimaryAction: () => localStorage.setItem('showAlphaSurvey', 'false'),
-          onPermanentDismiss: () => localStorage.setItem('showAlphaSurvey', 'false'),
-        });
-        markAlphaSurveyPrompted();
+        showAlphaSurveyToast();
       }
     }
     const req = ++playRequest.current;
@@ -1518,11 +1516,7 @@ function App() {
     if (!options?.preview) {
       playsRef.current++;
       if (localStorage.getItem('showAlphaSurvey') !== 'false' && playsRef.current >= 2) {
-        showNotiToast('alpha-feedback', {
-          onPrimaryAction: () => localStorage.setItem('showAlphaSurvey', 'false'),
-          onPermanentDismiss: () => localStorage.setItem('showAlphaSurvey', 'false'),
-        });
-        markAlphaSurveyPrompted();
+        showAlphaSurveyToast();
       }
     }
     const req = ++playRequest.current;
@@ -2020,10 +2014,7 @@ function App() {
     setRestoreGenreCardOnArtistDismiss(false); // Direct node click, don't restore genre card
     artistNodeClicksRef.current++;
     if (localStorage.getItem('showAlphaSurvey') !== 'false' && artistNodeClicksRef.current >= 5) {
-      showNotiToast('alpha-feedback', {
-        onPrimaryAction: () => localStorage.setItem('showAlphaSurvey', 'false'),
-      });
-      markAlphaSurveyPrompted();
+      showAlphaSurveyToast();
     }
     if (graph === 'artists') {
       setSelectedArtist(artist); // For graph focus/dimming
@@ -2707,10 +2698,7 @@ function App() {
         // Logic for alpha survey triggering
         artistsAddedRef.current++;
         if (localStorage.getItem('showAlphaSurvey') !== 'false' && artistsAddedRef.current >= ALPHA_SURVEY_ADDED_ARTISTS) {
-          showNotiToast('alpha-feedback', {
-            onPrimaryAction: () => localStorage.setItem('showAlphaSurvey', 'false'),
-          });
-          markAlphaSurveyPrompted();
+          showAlphaSurveyToast();
         }
       }
     } else {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -430,6 +430,8 @@ function App() {
   });
 
   const artistsAddedRef = useRef(0);
+  const artistNodeClicksRef = useRef(0);
+  const playsRef = useRef(0);
 
   // Returns true if the alpha survey should be shown this session.
   // Gates on session 2+ and ensures at least 2 sessions between re-prompts.
@@ -1449,6 +1451,15 @@ function App() {
 
   // Play handlers using embedded YouTube player
   const onPlayArtist = async (artist: Artist, options?: { preview?: boolean }) => {
+    if (!options?.preview) {
+      playsRef.current++;
+      if (localStorage.getItem('showAlphaSurvey') !== 'false' && playsRef.current >= 2) {
+        showNotiToast('alpha-feedback', {
+          onPrimaryAction: () => localStorage.setItem('showAlphaSurvey', 'false'),
+        });
+        markAlphaSurveyPrompted();
+      }
+    }
     const req = ++playRequest.current;
     const artistLoadingKey = `artist:${artist.id}`;
     setPlayerPreviewMode(options?.preview ?? false);
@@ -1502,6 +1513,15 @@ function App() {
   };
 
   const onPlayGenre = async (genre: Genre, options?: { preview?: boolean }) => {
+    if (!options?.preview) {
+      playsRef.current++;
+      if (localStorage.getItem('showAlphaSurvey') !== 'false' && playsRef.current >= 2) {
+        showNotiToast('alpha-feedback', {
+          onPrimaryAction: () => localStorage.setItem('showAlphaSurvey', 'false'),
+        });
+        markAlphaSurveyPrompted();
+      }
+    }
     const req = ++playRequest.current;
     const genreLoadingKey = `genre:${genre.id}`;
     setPlayerPreviewMode(options?.preview ?? false);
@@ -1995,6 +2015,13 @@ function App() {
     setSelectedArtistFromSearch(false);
     setArtistPreviewStack([]);
     setRestoreGenreCardOnArtistDismiss(false); // Direct node click, don't restore genre card
+    artistNodeClicksRef.current++;
+    if (localStorage.getItem('showAlphaSurvey') !== 'false' && artistNodeClicksRef.current >= 5) {
+      showNotiToast('alpha-feedback', {
+        onPrimaryAction: () => localStorage.setItem('showAlphaSurvey', 'false'),
+      });
+      markAlphaSurveyPrompted();
+    }
     if (graph === 'artists') {
       setSelectedArtist(artist); // For graph focus/dimming
       setArtistInfoToShow(artist); // For drawer display

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -431,7 +431,21 @@ function App() {
 
   const artistsAddedRef = useRef(0);
 
-  // Get hovered artist data for preview
+  // Returns true if the alpha survey should be shown this session.
+  // Gates on session 2+ and ensures at least 2 sessions between re-prompts.
+  function shouldShowAlphaSurvey(): boolean {
+    if (localStorage.getItem('showAlphaSurvey') === 'false') return false;
+    const sessionCount = parseInt(localStorage.getItem('rhizomeSessionCount') || '1');
+    if (sessionCount < 2) return false;
+    const lastPromptedSession = parseInt(localStorage.getItem('alphaSurveyLastSession') || '0');
+    return lastPromptedSession === 0 || sessionCount >= lastPromptedSession + 2;
+  }
+
+  function markAlphaSurveyPrompted(): void {
+    const sessionCount = parseInt(localStorage.getItem('rhizomeSessionCount') || '1');
+    localStorage.setItem('alphaSurveyLastSession', sessionCount.toString());
+  }
+
   const hoveredArtistData = useMemo(() => {
     if (!previewArtist) return null;
     return currentArtists.find((a) => a.id === previewArtist.id) || null;
@@ -445,12 +459,20 @@ function App() {
     return () => window.removeEventListener('resize', update);
   }, []);
 
-  // Setup alpha feedback timer on mount
+  // Increment session count on each mount so survey triggers can gate on session number
+  useEffect(() => {
+    const count = parseInt(localStorage.getItem('rhizomeSessionCount') || '0') + 1;
+    localStorage.setItem('rhizomeSessionCount', count.toString());
+  }, []);
+
+  // Setup alpha feedback timer on mount — only fires from session 2 onward
   useEffect(() => {
     const timer = setTimeout(() => {
-      if (localStorage.getItem('showAlphaSurvey') !== 'false') {
-        showNotiToast('alpha-feedback');
-        localStorage.setItem('showAlphaSurvey', 'false');
+      if (shouldShowAlphaSurvey()) {
+        showNotiToast('alpha-feedback', {
+          onPrimaryAction: () => localStorage.setItem('showAlphaSurvey', 'false'),
+        });
+        markAlphaSurveyPrompted();
       }
     }, ALPHA_SURVEY_TIME_MS)
     return () => {
@@ -2655,8 +2677,10 @@ function App() {
         // Logic for alpha survey triggering
         artistsAddedRef.current++;
         if (localStorage.getItem('showAlphaSurvey') !== 'false' && artistsAddedRef.current >= ALPHA_SURVEY_ADDED_ARTISTS) {
-          showNotiToast('alpha-feedback');
-          localStorage.setItem('showAlphaSurvey', 'false');
+          showNotiToast('alpha-feedback', {
+            onPrimaryAction: () => localStorage.setItem('showAlphaSurvey', 'false'),
+          });
+          markAlphaSurveyPrompted();
         }
       }
     } else {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1456,7 +1456,7 @@ function App() {
   const onPlayArtist = async (artist: Artist, options?: { preview?: boolean }) => {
     if (!options?.preview) {
       playsRef.current++;
-      if (localStorage.getItem('showAlphaSurvey') !== 'false' && playsRef.current >= 2) {
+      if (localStorage.getItem('showAlphaSurvey') !== 'false' && playsRef.current >= 3) {
         showAlphaSurveyToast();
       }
     }
@@ -1515,7 +1515,7 @@ function App() {
   const onPlayGenre = async (genre: Genre, options?: { preview?: boolean }) => {
     if (!options?.preview) {
       playsRef.current++;
-      if (localStorage.getItem('showAlphaSurvey') !== 'false' && playsRef.current >= 2) {
+      if (localStorage.getItem('showAlphaSurvey') !== 'false' && playsRef.current >= 3) {
         showAlphaSurveyToast();
       }
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -473,6 +473,7 @@ function App() {
       if (shouldShowAlphaSurvey()) {
         showNotiToast('alpha-feedback', {
           onPrimaryAction: () => localStorage.setItem('showAlphaSurvey', 'false'),
+          onPermanentDismiss: () => localStorage.setItem('showAlphaSurvey', 'false'),
         });
         markAlphaSurveyPrompted();
       }
@@ -1456,6 +1457,7 @@ function App() {
       if (localStorage.getItem('showAlphaSurvey') !== 'false' && playsRef.current >= 2) {
         showNotiToast('alpha-feedback', {
           onPrimaryAction: () => localStorage.setItem('showAlphaSurvey', 'false'),
+          onPermanentDismiss: () => localStorage.setItem('showAlphaSurvey', 'false'),
         });
         markAlphaSurveyPrompted();
       }
@@ -1518,6 +1520,7 @@ function App() {
       if (localStorage.getItem('showAlphaSurvey') !== 'false' && playsRef.current >= 2) {
         showNotiToast('alpha-feedback', {
           onPrimaryAction: () => localStorage.setItem('showAlphaSurvey', 'false'),
+          onPermanentDismiss: () => localStorage.setItem('showAlphaSurvey', 'false'),
         });
         markAlphaSurveyPrompted();
       }

--- a/src/components/NotiToast.tsx
+++ b/src/components/NotiToast.tsx
@@ -54,6 +54,7 @@ interface NotiToastConfig {
     label: string;
   };
   onPrimaryAction?: () => void;
+  onPermanentDismiss?: () => void;
 }
 
 // add more noti types as needed
@@ -99,7 +100,7 @@ const notificationConfigs: Record<NotificationType, NotiToastConfig> = {
 /** Show a banner-style notification toast */
 export function showNotiToast(
   type: NotificationType,
-  options?: { feedbackFormUrl?: string; onPrimaryAction?: () => void }
+  options?: { feedbackFormUrl?: string; onPrimaryAction?: () => void; onPermanentDismiss?: () => void }
 ) {
   const config = notificationConfigs[type];
 
@@ -111,6 +112,7 @@ export function showNotiToast(
       ...(options?.feedbackFormUrl && { href: options.feedbackFormUrl }),
     },
     ...(options?.onPrimaryAction && { onPrimaryAction: options.onPrimaryAction }),
+    ...(options?.onPermanentDismiss && { onPermanentDismiss: options.onPermanentDismiss }),
   };
 
   return sonnerToast.custom(
@@ -218,6 +220,17 @@ function NotiToast({
             >
               Got it
             </Button>
+            {config.onPermanentDismiss && (
+              <Button
+                variant="ghost"
+                onClick={() => {
+                  config.onPermanentDismiss!();
+                  sonnerToast.dismiss(id);
+                }}
+              >
+                Don't show again
+              </Button>
+            )}
           </div>
         </>
       )}

--- a/src/components/NotiToast.tsx
+++ b/src/components/NotiToast.tsx
@@ -53,6 +53,7 @@ interface NotiToastConfig {
   dismissButton: {
     label: string;
   };
+  onPrimaryAction?: () => void;
 }
 
 // add more noti types as needed
@@ -98,7 +99,7 @@ const notificationConfigs: Record<NotificationType, NotiToastConfig> = {
 /** Show a banner-style notification toast */
 export function showNotiToast(
   type: NotificationType,
-  options?: { feedbackFormUrl?: string }
+  options?: { feedbackFormUrl?: string; onPrimaryAction?: () => void }
 ) {
   const config = notificationConfigs[type];
 
@@ -109,6 +110,7 @@ export function showNotiToast(
       ...config.primaryButton,
       ...(options?.feedbackFormUrl && { href: options.feedbackFormUrl }),
     },
+    ...(options?.onPrimaryAction && { onPrimaryAction: options.onPrimaryAction }),
   };
 
   return sonnerToast.custom(
@@ -147,6 +149,8 @@ function NotiToast({
       config.primaryButton.onClick();
       sonnerToast.dismiss(id);
     }
+
+    config.onPrimaryAction?.();
   };
 
   // When the user has acknowledged (tapped "No thanks"), we swap content


### PR DESCRIPTION
- Survey no longer permanently suppressed the moment it appears; the
  localStorage flag is now only set when the user clicks "Share Feedback"
  (clicking "Maybe later" allows it to re-surface in a future session)
- Time-based trigger is gated to session 2+ so first-time visitors aren't
  asked for feedback before they've formed an opinion
- Re-prompt interval: at least 2 sessions must pass between prompts to
  avoid spamming returning users
- Artist-count trigger unchanged in behaviour but now also participates
  in the permanent-dismissal and re-prompt tracking
