### PR TITLE
Feat/search improvements

### DIFF
--- a/src/components/AppSideBar.tsx
+++ b/src/components/AppSideBar.tsx
@@ -198,7 +198,7 @@ export function AppSidebar({
                     <RecentsPopover
                       onItemSelect={onRecentsSelect}
                       isCollapsed={isCollapsed}
-                      onSearchOpen={() => setSearchOpen(true)}
+                      onSearchOpen={() => window.dispatchEvent(new Event('search:open-recents'))}
                       getArtistImageByName={getArtistImageByName}
                       getArtistByName={getArtistByName}
                       getArtistColor={getArtistColor}

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -4,10 +4,11 @@ import { Badge } from "@/components/ui/badge"
 import { BadgeIndicator } from "@/components/BadgeIndicator"
 import { SearchEmptyState } from "@/components/SearchEmptyState"
 import { useRecentSelections, groupByTime } from "@/hooks/useRecentSelections"
-import { X, Search as SearchIcon, CirclePlay, HandHeart, SunMoon, Sun, Moon, Sparkles } from "lucide-react"
+import { X, Search as SearchIcon, CirclePlay, HandHeart, SunMoon, Sun, Moon, Sparkles, Share2 } from "lucide-react"
 import axios from "axios"
 import { motion } from "framer-motion";
 import { isGenre, serverUrl } from "@/lib/utils"
+import { toast } from "sonner"
 import { Artist, BasicNode, Genre, GraphType } from "@/types";
 import { useEffect, useRef, useState } from "react";
 import { useMemo } from "react";
@@ -273,6 +274,20 @@ export function Search({
       keywords: ['support', 'donate', 'ko-fi', 'kofi', 'coffee', 'tip', 'contribute'],
       icon: KofiIcon,
       onSelect: () => { window.open('https://ko-fi.com/rhizomefyi', '_blank') }
+    },
+    {
+      id: 'share',
+      label: 'Share Rhizome',
+      keywords: ['share', 'copy', 'link', 'url', 'clipboard'],
+      icon: Share2,
+      onSelect: async () => {
+        try {
+          await navigator.clipboard.writeText("https://rhizome.fyi");
+          toast.success("Link copied to clipboard");
+        } catch {
+          toast.error("Failed to copy link");
+        }
+      }
     },
     {
       id: 'surprise-me',

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -4,7 +4,7 @@ import { Badge } from "@/components/ui/badge"
 import { BadgeIndicator } from "@/components/BadgeIndicator"
 import { SearchEmptyState } from "@/components/SearchEmptyState"
 import { useRecentSelections, groupByTime } from "@/hooks/useRecentSelections"
-import { X, Search as SearchIcon, CirclePlay, HandHeart, SunMoon, Sun, Moon, Sparkles, Share2 } from "lucide-react"
+import { X, Search as SearchIcon, CirclePlay, HandHeart, SunMoon, Sun, Moon, Sparkles, Share2, History, ArrowLeft } from "lucide-react"
 import axios from "axios"
 import { motion } from "framer-motion";
 import { isGenre, serverUrl } from "@/lib/utils"
@@ -24,6 +24,16 @@ import KofiLogo from "@/assets/kofi_symbol.svg"
 const KofiIcon = ({ className }: { className?: string }) => (
   <img src={KofiLogo} alt="" className={className} />
 );
+
+interface SearchAction {
+  id: string;
+  label: string;
+  keywords: string[];
+  icon: React.ComponentType<{ className?: string }>;
+  onSelect: () => void;
+  // Actions like "View Recents" navigate within the dialog instead of leaving it
+  keepOpen?: boolean;
+}
 
 interface SearchProps {
   onGenreSelect: (genre: Genre) => void;
@@ -71,6 +81,7 @@ export function Search({
   const [cmdCtrlHeld, setCmdCtrlHeld] = useState(false);
   const [altHeld, setAltHeld] = useState(false);
   const [selectedValue, setSelectedValue] = useState<string>("");
+  const [view, setView] = useState<'root' | 'recents'>('root');
   const { recentSelections, addRecentSelection, removeRecentSelection } = useRecentSelections();
   const { searchResults, searchLoading, searchError } = useSearch(query);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -78,13 +89,29 @@ export function Search({
   // (inputValue ahead of query) and the in-flight request
   const searchPending = inputValue.trim() !== "" && (searchLoading || inputValue !== query);
 
-  // Debouncing
+  // Debouncing. The recents view filters locally, so no server query there
   useEffect(() => {
     const timeout = setTimeout(() => {
-      setQuery(inputValue);
+      setQuery(view === 'root' ? inputValue : "");
     }, SEARCH_DEBOUNCE_MS);
     return () => clearTimeout(timeout);
-  }, [inputValue]);
+  }, [inputValue, view]);
+
+  // Reset to the root view whenever the dialog closes
+  useEffect(() => {
+    if (!open) setView('root');
+  }, [open]);
+
+  // Lets the sidebar's "View all" open the dialog straight into recents
+  useEffect(() => {
+    const openRecents = () => {
+      setInputValue("");
+      setView('recents');
+      setOpen(true);
+    };
+    window.addEventListener('search:open-recents', openRecents);
+    return () => window.removeEventListener('search:open-recents', openRecents);
+  }, [setOpen]);
 
   // Reset selected value when input changes to keep cmdk selection in sync
   useEffect(() => {
@@ -253,7 +280,18 @@ export function Search({
   const { theme, setTheme } = useTheme()
 
   // Define searchable actions
-  const searchableActions = useMemo(() => [
+  const searchableActions = useMemo<SearchAction[]>(() => [
+    {
+      id: 'view-recents',
+      label: 'View Recents',
+      keywords: ['recents', 'recent', 'history', 'view all'],
+      icon: History,
+      keepOpen: true,
+      onSelect: () => {
+        setInputValue("");
+        setView('recents');
+      }
+    },
     {
       id: 'feedback',
       label: 'Give Feedback',
@@ -323,8 +361,76 @@ export function Search({
     return map;
   }, [recentSelections, filteredSearchableItems]);
 
+  // Recents filtered by the input while in the recents view
+  const recentsViewItems = useMemo(() => {
+    const q = inputValue.trim().toLowerCase();
+    return q ? recentSelections.filter((r) => r.name.toLowerCase().includes(q)) : recentSelections;
+  }, [recentSelections, inputValue]);
+
+  // Time-bucketed recents groups, shared by the root and recents views
+  const renderRecentsGroups = (items: typeof recentSelections) =>
+    groupByTime(items).map((bucket) => (
+      <CommandGroup key={bucket.label} heading={bucket.label}>
+        {bucket.items.map((selection) => {
+          const meta = getIndicatorMeta(selection);
+          const isGenreSelection = meta.type === 'genre';
+          return (
+            <CommandItem
+              key={selection.id}
+              value={selection.id}
+              onSelect={() => handleItemAction(selection)}
+              className="flex items-center justify-between gap-2"
+            >
+              <div className="flex min-w-0 items-center gap-2">
+                {shiftHeld && selectedValue === selection.id ? (
+                  <CirclePlay className="size-4 flex-shrink-0" />
+                ) : (
+                  <div className={`flex items-center ${isGenreSelection ? 'p-1.5' : ''}`}>
+                    <BadgeIndicator
+                      type={meta.type}
+                      name={selection.name}
+                      color={meta.color}
+                      imageUrl={meta.imageUrl}
+                      className={cn('flex-shrink-0', isGenreSelection ? 'size-2' : undefined)}
+                    />
+                  </div>
+                )}
+                <span className="truncate">{selection.name}</span>
+              </div>
+              <div className="flex items-center gap-2 flex-shrink-0">
+                {getActionHint(selection, selectedValue === selection.id) && (
+                  <span className="text-xs text-muted-foreground">
+                    {getActionHint(selection, selectedValue === selection.id)}
+                  </span>
+                )}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    removeRecentSelection(selection.id);
+                  }}
+                  className="-m-2"
+                >
+                  <X />
+                </Button>
+              </div>
+            </CommandItem>
+          );
+        })}
+      </CommandGroup>
+    ));
+
   // Intercept keyboard events in capture phase before cmdk processes them
   const handleKeyDownCapture = (e: React.KeyboardEvent) => {
+    // Backspace on an empty input backs out of the recents view
+    if (e.key === 'Backspace' && view === 'recents' && inputValue === '') {
+      e.preventDefault();
+      e.stopPropagation();
+      setView('root');
+      return;
+    }
+
     if (e.key !== 'Enter') return;
 
     const isCmdOrCtrl = e.metaKey || e.ctrlKey;
@@ -427,12 +533,33 @@ export function Search({
       >
         <div onKeyDownCapture={handleKeyDownCapture} className="flex flex-col h-full">
         <CommandInput
-            placeholder="Search..."
+            placeholder={view === 'recents' ? "Filter recents..." : "Search..."}
             value={inputValue}
             onValueChange={setInputValue}
             ref={inputRef}
         />
         <CommandList className="max-h-none flex-1 overflow-y-auto">
+          {view === 'recents' && (
+            <>
+              <CommandGroup>
+                <CommandItem value="__back" onSelect={() => setView('root')}>
+                  <ArrowLeft className="mr-2 size-4" />
+                  Back
+                </CommandItem>
+              </CommandGroup>
+              {recentsViewItems.length > 0 ? (
+                renderRecentsGroups(recentsViewItems)
+              ) : (
+                <div className="py-10 text-center text-sm text-muted-foreground">
+                  {recentSelections.length > 0
+                    ? "No recents match your filter."
+                    : "Nothing here yet. Artists and genres you select will show up here."}
+                </div>
+              )}
+            </>
+          )}
+          {view === 'root' && (
+          <>
           {searchPending && filteredSearchableItems.length === 0 && (
               <CommandGroup heading="Search Results">
                 {["w-40", "w-28", "w-36", "w-24", "w-32"].map((width, i) => (
@@ -449,7 +576,7 @@ export function Search({
           {!searchPending && inputValue.trim() !== "" && filteredSearchableItems.length === 0 && (
               <SearchEmptyState variant="no-results" query={inputValue.trim()} />
           )}
-          {!inputValue && recentSelections.length === 0 && (
+          {!inputValue && (
               <SearchEmptyState
                   variant="idle"
                   onSeedSelect={(seed) => {
@@ -503,57 +630,6 @@ export function Search({
               </CommandGroup>
           )}
 
-          {!inputValue && recentSelections.length > 0 && groupByTime(recentSelections).map((bucket) => (
-              <CommandGroup key={bucket.label} heading={bucket.label}>
-                {bucket.items.map((selection) => {
-                  const meta = getIndicatorMeta(selection);
-                  const isGenreSelection = meta.type === 'genre';
-                  return (
-                    <CommandItem
-                      key={selection.id}
-                      value={selection.id}
-                      onSelect={() => handleItemAction(selection)}
-                      className="flex items-center justify-between gap-2"
-                    >
-                      <div className="flex min-w-0 items-center gap-2">
-                        {shiftHeld && selectedValue === selection.id ? (
-                          <CirclePlay className="size-4 flex-shrink-0" />
-                        ) : (
-                          <div className={`flex items-center ${isGenreSelection ? 'p-1.5' : ''}`}>
-                            <BadgeIndicator
-                              type={meta.type}
-                              name={selection.name}
-                              color={meta.color}
-                              imageUrl={meta.imageUrl}
-                              className={cn('flex-shrink-0', isGenreSelection ? 'size-2' : undefined)}
-                            />
-                          </div>
-                        )}
-                        <span className="truncate">{selection.name}</span>
-                      </div>
-                      <div className="flex items-center gap-2 flex-shrink-0">
-                        {getActionHint(selection, selectedValue === selection.id) && (
-                          <span className="text-xs text-muted-foreground">
-                            {getActionHint(selection, selectedValue === selection.id)}
-                          </span>
-                        )}
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            removeRecentSelection(selection.id);
-                          }}
-                          className="-m-2"
-                        >
-                          <X />
-                        </Button>
-                      </div>
-                    </CommandItem>
-                  );
-                })}
-              </CommandGroup>
-            ))}
           {filteredActions.length > 0 && (
           <CommandGroup heading="Actions">
             {filteredActions.map((action) => {
@@ -561,7 +637,7 @@ export function Search({
               return (
                 <CommandItem
                   key={action.id}
-                  onSelect={() => { setOpen(false); action.onSelect(); }}
+                  onSelect={() => { if (!action.keepOpen) setOpen(false); action.onSelect(); }}
                 >
                   <Icon className="mr-2 size-4" />
                   {action.label}
@@ -570,7 +646,8 @@ export function Search({
             })}
           </CommandGroup>
           )}
-       
+          </>
+          )}
         </CommandList>
         {/* Shortcut Legend */}
         {!isMobile && <div className="w-full justify-end p-3 flex gap-3 bg-background border-t">

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -4,9 +4,10 @@ import { Badge } from "@/components/ui/badge"
 import { BadgeIndicator } from "@/components/BadgeIndicator"
 import { SearchEmptyState } from "@/components/SearchEmptyState"
 import { useRecentSelections, groupByTime } from "@/hooks/useRecentSelections"
-import { X, Search as SearchIcon, CirclePlay, HandHeart, SunMoon, Sun, Moon } from "lucide-react"
+import { X, Search as SearchIcon, CirclePlay, HandHeart, SunMoon, Sun, Moon, Sparkles } from "lucide-react"
+import axios from "axios"
 import { motion } from "framer-motion";
-import { isGenre } from "@/lib/utils"
+import { isGenre, serverUrl } from "@/lib/utils"
 import { Artist, BasicNode, Genre, GraphType } from "@/types";
 import { useEffect, useRef, useState } from "react";
 import { useMemo } from "react";
@@ -272,8 +273,22 @@ export function Search({
       keywords: ['support', 'donate', 'ko-fi', 'kofi', 'coffee', 'tip', 'contribute'],
       icon: KofiIcon,
       onSelect: () => { window.open('https://ko-fi.com/rhizomefyi', '_blank') }
+    },
+    {
+      id: 'surprise-me',
+      label: 'Surprise Me',
+      keywords: ['surprise', 'random', 'shuffle', 'discover', 'lucky', 'serendipity'],
+      icon: Sparkles,
+      onSelect: async () => {
+        try {
+          const response = await axios.get(`${serverUrl()}/search/random/node`);
+          if (response.data?.id) onItemSelect(response.data);
+        } catch {
+          // Leave the palette open; nothing to select
+        }
+      }
     }
-  ], [theme, setTheme]);
+  ], [theme, setTheme, onItemSelect]);
 
   // Filter actions based on input
   const filteredActions = useMemo(() => {

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -17,6 +17,11 @@ import { useMediaQuery } from "react-responsive";
 import useSearch from "@/hooks/useSearch";
 import {SEARCH_DEBOUNCE_MS} from "@/constants";
 import { Kbd } from "./ui/kbd"
+import KofiLogo from "@/assets/kofi_symbol.svg"
+
+const KofiIcon = ({ className }: { className?: string }) => (
+  <img src={KofiLogo} alt="" className={className} />
+);
 
 interface SearchProps {
   onGenreSelect: (genre: Genre) => void;
@@ -260,6 +265,13 @@ export function Search({
       keywords: ['theme', 'dark', 'light', 'mode', 'switch', 'toggle', 'dark mode', 'light mode'],
       icon: theme === "dark" ? Sun : Moon,
       onSelect: () => { setTheme(theme === "light" ? "dark" : "light") }
+    },
+    {
+      id: 'support',
+      label: 'Support Rhizome',
+      keywords: ['support', 'donate', 'ko-fi', 'kofi', 'coffee', 'tip', 'contribute'],
+      icon: KofiIcon,
+      onSelect: () => { window.open('https://ko-fi.com/rhizomefyi', '_blank') }
     }
   ], [theme, setTheme]);
 

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -262,13 +262,6 @@ export function Search({
       onSelect: () => { window.dispatchEvent(new Event('feedback:open')) }
     },
     {
-      id: 'toggle-theme',
-      label: theme === "dark" ? "Switch to Light Mode" : "Switch to Dark Mode",
-      keywords: ['theme', 'dark', 'light', 'mode', 'switch', 'toggle', 'dark mode', 'light mode'],
-      icon: theme === "dark" ? Sun : Moon,
-      onSelect: () => { setTheme(theme === "light" ? "dark" : "light") }
-    },
-    {
       id: 'support',
       label: 'Support Rhizome',
       keywords: ['support', 'donate', 'ko-fi', 'kofi', 'coffee', 'tip', 'contribute'],
@@ -302,6 +295,13 @@ export function Search({
           // Leave the palette open; nothing to select
         }
       }
+    },
+    {
+      id: 'toggle-theme',
+      label: theme === "dark" ? "Switch to Light Mode" : "Switch to Dark Mode",
+      keywords: ['theme', 'dark', 'light', 'mode', 'switch', 'toggle', 'dark mode', 'light mode'],
+      icon: theme === "dark" ? Sun : Moon,
+      onSelect: () => { setTheme(theme === "light" ? "dark" : "light") }
     }
   ], [theme, setTheme, onItemSelect]);
 
@@ -561,7 +561,7 @@ export function Search({
               return (
                 <CommandItem
                   key={action.id}
-                  onSelect={action.onSelect}
+                  onSelect={() => { setOpen(false); action.onSelect(); }}
                 >
                   <Icon className="mr-2 size-4" />
                   {action.label}

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -9,7 +9,7 @@ import { isGenre } from "@/lib/utils"
 import { Artist, BasicNode, Genre, GraphType } from "@/types";
 import { useEffect, useRef, useState } from "react";
 import { useMemo } from "react";
-import { Loading } from "@/components/Loading";
+import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils"
 import { useTheme } from "next-themes"
 import { useMediaQuery } from "react-responsive";
@@ -66,6 +66,9 @@ export function Search({
   const { recentSelections, addRecentSelection, removeRecentSelection } = useRecentSelections();
   const { searchResults, searchLoading, searchError } = useSearch(query);
   const inputRef = useRef<HTMLInputElement>(null);
+  // True from first keystroke until results land: covers the debounce window
+  // (inputValue ahead of query) and the in-flight request
+  const searchPending = inputValue.trim() !== "" && (searchLoading || inputValue !== query);
 
   // Debouncing
   useEffect(() => {
@@ -386,8 +389,20 @@ export function Search({
             ref={inputRef}
         />
         <CommandList className="max-h-none flex-1 overflow-y-auto">
-          {searchLoading && <Loading />}
-          {!searchLoading && inputValue === query && <CommandEmpty>{inputValue ? "No results found." : "Start typing to search..."}</CommandEmpty>}
+          {searchPending && filteredSearchableItems.length === 0 && (
+              <CommandGroup heading="Search Results">
+                {["w-40", "w-28", "w-36", "w-24", "w-32"].map((width, i) => (
+                  <div key={i} className="flex items-center justify-between gap-2 px-2 py-1.5">
+                    <div className="flex min-w-0 items-center gap-2">
+                      <Skeleton className="bg-accent size-5 flex-shrink-0 rounded-full" />
+                      <Skeleton className={`bg-accent h-4 ${width}`} />
+                    </div>
+                    <Skeleton className="bg-accent h-6 w-12 rounded-sm" />
+                  </div>
+                ))}
+              </CommandGroup>
+          )}
+          {!searchPending && <CommandEmpty>{inputValue ? "No results found." : "Start typing to search..."}</CommandEmpty>}
           {inputValue.trim() !== "" && filteredSearchableItems.length > 0 && (
               <CommandGroup heading="Search Results">
                 {filteredSearchableItems.map((item, i) => {

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -413,6 +413,10 @@ export function Search({
                     setInputValue(seed);
                     inputRef.current?.focus();
                   }}
+                  getArtistImage={(name) => {
+                    const artist = currentArtists.find((a) => a.name === name);
+                    return typeof artist?.image === "string" && artist.image.trim() ? artist.image : undefined;
+                  }}
               />
           )}
           {inputValue.trim() !== "" && filteredSearchableItems.length > 0 && (

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -405,6 +405,7 @@ export function Search({
           open={open}
           onOpenChange={setOpen}
           shouldFilter={false}
+          loop
           value={selectedValue}
           onValueChange={setSelectedValue}
           className="h-[400px] sm:h-[500px] md:h-[600px] lg:h-[600px] sm:max-w-xl md:max-w-xl lg:max-w-3xl w-full"

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -85,6 +85,7 @@ export function Search({
   const { recentSelections, addRecentSelection, removeRecentSelection } = useRecentSelections();
   const { searchResults, searchLoading, searchError } = useSearch(query);
   const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
   // True from first keystroke until results land: covers the debounce window
   // (inputValue ahead of query) and the in-flight request
   const searchPending = inputValue.trim() !== "" && (searchLoading || inputValue !== query);
@@ -101,6 +102,11 @@ export function Search({
   useEffect(() => {
     if (!open) setView('root');
   }, [open]);
+
+  // Scroll list to top whenever entering the recents view
+  useEffect(() => {
+    if (view === 'recents') listRef.current?.scrollTo({ top: 0 });
+  }, [view]);
 
   // Lets the sidebar's "View all" open the dialog straight into recents
   useEffect(() => {
@@ -538,7 +544,7 @@ export function Search({
             onValueChange={setInputValue}
             ref={inputRef}
         />
-        <CommandList className="max-h-none flex-1 overflow-y-auto">
+        <CommandList ref={listRef} className="max-h-none flex-1 overflow-y-auto">
           {view === 'recents' && (
             <>
               <CommandGroup>

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -394,8 +394,8 @@ export function Search({
                 {["w-40", "w-28", "w-36", "w-24", "w-32"].map((width, i) => (
                   <div key={i} className="flex items-center justify-between gap-2 px-2 py-1.5">
                     <div className="flex min-w-0 items-center gap-2">
-                      <Skeleton className="bg-accent size-5 flex-shrink-0 rounded-full" />
-                      <Skeleton className={`bg-accent h-4 ${width}`} />
+                      <Skeleton className="bg-accent size-6 flex-shrink-0 rounded-full" />
+                      <Skeleton className={`bg-accent h-6 ${width}`} />
                     </div>
                     <Skeleton className="bg-accent h-6 w-12 rounded-sm" />
                   </div>

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -538,21 +538,28 @@ export function Search({
           className="h-[400px] sm:h-[500px] md:h-[600px] lg:h-[600px] sm:max-w-xl md:max-w-xl lg:max-w-3xl w-full"
       >
         <div onKeyDownCapture={handleKeyDownCapture} className="flex flex-col h-full">
-        <CommandInput
-            placeholder={view === 'recents' ? "Filter recents..." : "Search..."}
-            value={inputValue}
-            onValueChange={setInputValue}
-            ref={inputRef}
-        />
+        <div className="flex items-center border-b [&_[data-slot=command-input-wrapper]]:border-b-0 [&_[data-slot=command-input-wrapper]]:flex-1">
+          {view === 'recents' && (
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => setView('root')}
+              className="mb-0.5 ml-2"
+              aria-label="Back"
+            >
+              <ArrowLeft className="size-4" />
+            </Button>
+          )}
+          <CommandInput
+              placeholder={view === 'recents' ? "Filter recents..." : "Search..."}
+              value={inputValue}
+              onValueChange={setInputValue}
+              ref={inputRef}
+          />
+        </div>
         <CommandList ref={listRef} className="max-h-none flex-1 overflow-y-auto">
           {view === 'recents' && (
             <>
-              <CommandGroup>
-                <CommandItem value="__back" onSelect={() => setView('root')}>
-                  <ArrowLeft className="mr-2 size-4" />
-                  Back
-                </CommandItem>
-              </CommandGroup>
               {recentsViewItems.length > 0 ? (
                 renderRecentsGroups(recentsViewItems)
               ) : (

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -1,7 +1,8 @@
 import { Button } from "@/components/ui/button"
-import { CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator } from "@/components/ui/command"
+import { CommandDialog, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator } from "@/components/ui/command"
 import { Badge } from "@/components/ui/badge"
 import { BadgeIndicator } from "@/components/BadgeIndicator"
+import { SearchEmptyState } from "@/components/SearchEmptyState"
 import { useRecentSelections, groupByTime } from "@/hooks/useRecentSelections"
 import { X, Search as SearchIcon, CirclePlay, HandHeart, SunMoon, Sun, Moon } from "lucide-react"
 import { motion } from "framer-motion";
@@ -402,7 +403,18 @@ export function Search({
                 ))}
               </CommandGroup>
           )}
-          {!searchPending && <CommandEmpty>{inputValue ? "No results found." : "Start typing to search..."}</CommandEmpty>}
+          {!searchPending && inputValue.trim() !== "" && filteredSearchableItems.length === 0 && (
+              <SearchEmptyState variant="no-results" query={inputValue.trim()} />
+          )}
+          {!inputValue && recentSelections.length === 0 && (
+              <SearchEmptyState
+                  variant="idle"
+                  onSeedSelect={(seed) => {
+                    setInputValue(seed);
+                    inputRef.current?.focus();
+                  }}
+              />
+          )}
           {inputValue.trim() !== "" && filteredSearchableItems.length > 0 && (
               <CommandGroup heading="Search Results">
                 {filteredSearchableItems.map((item, i) => {

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -115,25 +115,24 @@ export function Search({
   }, []);
 
 
-  // Filter the searchable items. This is problematic with bands of the same name, for now it just uses the first one in the results
+  // Local items (graph artists + genres) are substring-filtered; server results are already
+  // matched by the backend (prefix/fuzzy), so they pass through as-is. Duplicate names within
+  // a type collapse to the first occurrence — bands sharing a name aren't distinguishable here yet
   const filteredSearchableItems = useMemo(() => {
+    const search = inputValue.trim().toLowerCase();
+    const localMatches = search
+      ? [...currentArtists, ...genres].filter((item) => item.name.toLowerCase().includes(search))
+      : [];
+    const seenIds = new Set<string>();
     const seenNames = new Set<string>();
-    return [...currentArtists, ...searchResults, ...genres].filter((item) => {
-      if (!item.name.toLowerCase().includes(inputValue.toLowerCase())) return false;
-      if (seenNames.has(item.name)) return false;
-      seenNames.add(item.name);
+    return [...localMatches, ...searchResults].filter((item) => {
+      const nameKey = `${isGenre(item) ? 'genre' : 'artist'}:${item.name.toLowerCase()}`;
+      if (seenIds.has(item.id) || seenNames.has(nameKey)) return false;
+      seenIds.add(item.id);
+      seenNames.add(nameKey);
       return true;
-    }
-    )},
-      [genres, searchResults, currentArtists, inputValue]
-  );
-
-  // Check if filtered items include any actual search results
-  const hasSearchResults = useMemo(() => {
-    if (!query || searchResults.length === 0) return false;
-    const searchResultIds = new Set(searchResults.map(r => r.id));
-    return filteredSearchableItems.some(item => searchResultIds.has(item.id));
-  }, [query, searchResults, filteredSearchableItems]);
+    });
+  }, [genres, searchResults, currentArtists, inputValue]);
 
   const isArtistWithDetail = (node: BasicNode): node is Artist => {
     return 'tags' in node && Array.isArray((node as Artist).tags);
@@ -389,7 +388,7 @@ export function Search({
         <CommandList className="max-h-none flex-1 overflow-y-auto">
           {searchLoading && <Loading />}
           {!searchLoading && inputValue === query && <CommandEmpty>{inputValue ? "No results found." : "Start typing to search..."}</CommandEmpty>}
-          {hasSearchResults && (
+          {inputValue.trim() !== "" && filteredSearchableItems.length > 0 && (
               <CommandGroup heading="Search Results">
                 {filteredSearchableItems.map((item, i) => {
                   const meta = getIndicatorMeta(item);

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -282,17 +282,6 @@ export function Search({
   // Define searchable actions
   const searchableActions = useMemo<SearchAction[]>(() => [
     {
-      id: 'view-recents',
-      label: 'View Recents',
-      keywords: ['recents', 'recent', 'history', 'view all'],
-      icon: History,
-      keepOpen: true,
-      onSelect: () => {
-        setInputValue("");
-        setView('recents');
-      }
-    },
-    {
       id: 'feedback',
       label: 'Give Feedback',
       keywords: ['feedback', 'give', 'report', 'suggest'],
@@ -332,6 +321,17 @@ export function Search({
         } catch {
           // Leave the palette open; nothing to select
         }
+      }
+    },
+    {
+      id: 'view-recents',
+      label: 'View Recents',
+      keywords: ['recents', 'recent', 'history', 'view all'],
+      icon: History,
+      keepOpen: true,
+      onSelect: () => {
+        setInputValue("");
+        setView('recents');
       }
     },
     {

--- a/src/components/SearchEmptyState.tsx
+++ b/src/components/SearchEmptyState.tsx
@@ -50,8 +50,8 @@ const edgePath = (a: { x: number; y: number }, b: { x: number; y: number }, i: n
 };
 
 const SEED_POOL = {
-  genre: ["shoegaze", "krautrock", "dub techno", "ambient", "post-punk", "trip hop", "zeuhl", "bossa nova"],
-  artist: ["Radiohead", "Aphex Twin", "Alice Coltrane", "Boards of Canada", "Fela Kuti", "Cocteau Twins", "Stereolab", "MF DOOM"],
+  genre: ["shoegaze", "krautrock", "dub techno", "ambient", "post-punk", "trip hop", "zeuhl", "bossa nova", "drone", "afrobeat"],
+  artist: ["Radiohead", "Aphex Twin", "Alice Coltrane", "Boards of Canada", "Fela Kuti", "Cocteau Twins", "Stereolab", "MF DOOM", "Portishead", "Can"],
 };
 
 const pickRandom = (pool: string[], count: number) =>
@@ -97,8 +97,8 @@ function Constellation({ animate, colors }: { animate: boolean; colors: string[]
       viewBox="0 0 214 120"
       className="w-52 text-muted-foreground"
       aria-hidden="true"
-      animate={animate ? { y: [0, -4, 0] } : undefined}
-      transition={{ duration: 7, repeat: Infinity, ease: "easeInOut" }}
+      animate={undefined}
+      transition={undefined}
     >
       {EDGES.map(([a, b], i) => (
         <motion.path
@@ -215,12 +215,15 @@ export function SearchEmptyState({ variant, query, onSeedSelect, getArtistImage 
   const animate = !reducedMotion;
   const colors = usePaletteColors();
 
-  // Two marquee rows of four, genres and artists interleaved
+  // Two marquee rows using the full pools (shuffled), genres and artists
+  // interleaved. Each row needs to be wider than the dialog so the duplicated
+  // loop copy is never visible alongside the original
   const seedRows = useMemo(() => {
-    const genreSeeds = pickRandom(SEED_POOL.genre, 4).map((label) => ({ label, type: "genre" as const }));
-    const artistSeeds = pickRandom(SEED_POOL.artist, 4).map((label) => ({ label, type: "artist" as const }));
+    const genreSeeds = pickRandom(SEED_POOL.genre, SEED_POOL.genre.length).map((label) => ({ label, type: "genre" as const }));
+    const artistSeeds = pickRandom(SEED_POOL.artist, SEED_POOL.artist.length).map((label) => ({ label, type: "artist" as const }));
     const interleaved = genreSeeds.flatMap((seed, i) => [seed, artistSeeds[i]]);
-    return [interleaved.slice(0, 4), interleaved.slice(4)];
+    const half = Math.ceil(interleaved.length / 2);
+    return [interleaved.slice(0, half), interleaved.slice(half)];
   }, []);
   const artistSeedNames = useMemo(
     () => (variant === "idle" ? seedRows.flat().filter((s) => s.type === "artist").map((s) => s.label) : []),
@@ -230,7 +233,7 @@ export function SearchEmptyState({ variant, query, onSeedSelect, getArtistImage 
 
   if (variant === "no-results") {
     return (
-      <div className="flex flex-col items-center gap-1 px-6 py-8 text-center">
+      <div className="flex h-full flex-col items-center justify-center gap-1 px-6 py-40 text-center">
         <SeveredEdge animate={animate} color={colors[2]} />
         <p className="text-md font-medium text-foreground">
           Didn't find anything for <span className="text-muted-foreground">&ldquo;{query}&rdquo;</span>
@@ -280,7 +283,7 @@ export function SearchEmptyState({ variant, query, onSeedSelect, getArtistImage 
                 style={animate ? { animationDuration: rowIdx === 0 ? "45s" : "60s" } : undefined}
               >
                 {(animate ? [...row, ...row] : row).map((seed, i) => {
-                  const colorIdx = (rowIdx * 4 + (i % row.length)) % colors.length;
+                  const colorIdx = (rowIdx * row.length + (i % row.length)) % colors.length;
                   return (
                     <div key={`${seed.label}-${i}`}>
                       {seed.type === "genre" ? (

--- a/src/components/SearchEmptyState.tsx
+++ b/src/components/SearchEmptyState.tsx
@@ -147,20 +147,65 @@ function Constellation({ animate, colors }: { animate: boolean; colors: string[]
   );
 }
 
+// Spark ticks radiating from the break point
+const SPARKS: [number, number, number, number][] = [
+  [56, 16, 52, 9],
+  [61, 14, 62, 7],
+  [66, 18, 72, 14],
+];
+
 function SeveredEdge({ animate, color }: { animate: boolean; color: string }) {
   return (
     <motion.svg
-      viewBox="0 0 120 40"
-      className="w-28 text-muted-foreground"
+      viewBox="0 0 120 44"
+      className="w-32 text-muted-foreground"
       aria-hidden="true"
       initial={animate ? { opacity: 0, y: 4 } : false}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.35, ease: "easeOut" }}
     >
-      <line x1="25" y1="20" x2="52" y2="20" stroke="currentColor" strokeWidth="1" strokeDasharray="3 4" opacity="0.5" />
-      <line x1="66" y1="24" x2="94" y2="22" stroke="currentColor" strokeWidth="1" strokeDasharray="3 4" opacity="0.35" />
-      <circle cx="18" cy="20" r="5" fill={color} />
-      <circle cx="101" cy="22" r="5" fill="none" stroke="currentColor" strokeWidth="1.25" opacity="0.6" />
+      {/* Two stubs recoiling from the break: ends curl away from each other */}
+      <motion.path
+        d="M 21 24 C 34 24 44 23 52 17"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeDasharray="3 3"
+        opacity="0.55"
+        initial={animate ? { pathLength: 0 } : false}
+        animate={{ pathLength: 1 }}
+        transition={{ duration: 0.4, delay: 0.1, ease: "easeOut" }}
+      />
+      <motion.path
+        d="M 99 26 C 87 27 77 30 69 36"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeDasharray="3 3"
+        opacity="0.4"
+        initial={animate ? { pathLength: 0 } : false}
+        animate={{ pathLength: 1 }}
+        transition={{ duration: 0.4, delay: 0.2, ease: "easeOut" }}
+      />
+      {/* Snap burst at the break */}
+      <g stroke={color} strokeWidth="1.5" strokeLinecap="round">
+        {SPARKS.map(([x1, y1, x2, y2], i) => (
+          <motion.line
+            key={`s-${i}`}
+            x1={x1}
+            y1={y1}
+            x2={x2}
+            y2={y2}
+            initial={animate ? { opacity: 0, scale: 0.4 } : false}
+            animate={{ opacity: [0, 1, 0.7], scale: 1 }}
+            transition={{ duration: 0.35, delay: 0.5 + i * 0.06, ease: "easeOut" }}
+            style={{ transformOrigin: "60px 17px" }}
+          />
+        ))}
+      </g>
+      <circle cx="14" cy="24" r="5" fill={color} />
+      {/* The far node hangs hollow, knocked slightly off the line */}
+      <circle cx="106" cy="27" r="5" fill="none" stroke="currentColor" strokeWidth="1.25" opacity="0.6" />
     </motion.svg>
   );
 }

--- a/src/components/SearchEmptyState.tsx
+++ b/src/components/SearchEmptyState.tsx
@@ -215,16 +215,16 @@ export function SearchEmptyState({ variant, query, onSeedSelect, getArtistImage 
   const animate = !reducedMotion;
   const colors = usePaletteColors();
 
-  const seeds = useMemo(
-    () => [
-      ...pickRandom(SEED_POOL.genre, 2).map((label) => ({ label, type: "genre" as const })),
-      ...pickRandom(SEED_POOL.artist, 2).map((label) => ({ label, type: "artist" as const })),
-    ],
-    []
-  );
+  // Two marquee rows of four, genres and artists interleaved
+  const seedRows = useMemo(() => {
+    const genreSeeds = pickRandom(SEED_POOL.genre, 4).map((label) => ({ label, type: "genre" as const }));
+    const artistSeeds = pickRandom(SEED_POOL.artist, 4).map((label) => ({ label, type: "artist" as const }));
+    const interleaved = genreSeeds.flatMap((seed, i) => [seed, artistSeeds[i]]);
+    return [interleaved.slice(0, 4), interleaved.slice(4)];
+  }, []);
   const artistSeedNames = useMemo(
-    () => (variant === "idle" ? seeds.filter((s) => s.type === "artist").map((s) => s.label) : []),
-    [seeds, variant]
+    () => (variant === "idle" ? seedRows.flat().filter((s) => s.type === "artist").map((s) => s.label) : []),
+    [seedRows, variant]
   );
   const seedImages = useSeedImages(artistSeedNames);
 
@@ -262,31 +262,48 @@ export function SearchEmptyState({ variant, query, onSeedSelect, getArtistImage 
         Type an artist or genre and the map unfolds from there.
       </motion.p>
       {onSeedSelect && (
-        <div className="mt-4 flex flex-wrap items-center justify-center gap-1.5">
-          {seeds.map((seed, i) => (
-            <motion.div
-              key={seed.label}
-              initial={animate ? { opacity: 0, y: 6 } : false}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.35, delay: 0.8 + i * 0.07, ease: "easeOut" }}
-            >
-              {seed.type === "genre" ? (
-                <GenreBadge
-                  name={seed.label}
-                  onClick={() => onSeedSelect(seed.label)}
-                  genreColor={colors[i % colors.length]}
-                />
-              ) : (
-                <ArtistBadge
-                  name={seed.label}
-                  onClick={() => onSeedSelect(seed.label)}
-                  genreColor={colors[i % colors.length]}
-                  imageUrl={getArtistImage?.(seed.label) ?? seedImages[seed.label]}
-                />
-              )}
-            </motion.div>
+        <motion.div
+          className="mt-4 w-full overflow-hidden [mask-image:linear-gradient(to_right,transparent,black_12%,black_88%,transparent)]"
+          initial={animate ? { opacity: 0, y: 6 } : false}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4, delay: 0.8, ease: "easeOut" }}
+        >
+          {seedRows.map((row, rowIdx) => (
+            <div key={rowIdx} className="group/marquee overflow-hidden py-1">
+              <div
+                className={
+                  animate
+                    ? "flex w-max gap-1.5 animate-[search-marquee_40s_linear_infinite] group-hover/marquee:[animation-play-state:paused]"
+                    : "flex flex-wrap justify-center gap-1.5"
+                }
+                // Slightly different speeds keep the rows from moving in lockstep
+                style={animate ? { animationDuration: rowIdx === 0 ? "45s" : "60s" } : undefined}
+              >
+                {(animate ? [...row, ...row] : row).map((seed, i) => {
+                  const colorIdx = (rowIdx * 4 + (i % row.length)) % colors.length;
+                  return (
+                    <div key={`${seed.label}-${i}`}>
+                      {seed.type === "genre" ? (
+                        <GenreBadge
+                          name={seed.label}
+                          onClick={() => onSeedSelect(seed.label)}
+                          genreColor={colors[colorIdx]}
+                        />
+                      ) : (
+                        <ArtistBadge
+                          name={seed.label}
+                          onClick={() => onSeedSelect(seed.label)}
+                          genreColor={colors[colorIdx]}
+                          imageUrl={getArtistImage?.(seed.label) ?? seedImages[seed.label]}
+                        />
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
           ))}
-        </div>
+        </motion.div>
       )}
     </div>
   );

--- a/src/components/SearchEmptyState.tsx
+++ b/src/components/SearchEmptyState.tsx
@@ -230,7 +230,7 @@ export function SearchEmptyState({ variant, query, onSeedSelect, getArtistImage 
 
   if (variant === "no-results") {
     return (
-      <div className="flex flex-col items-center gap-1 px-6 py-12 text-center">
+      <div className="flex flex-col items-center gap-1 px-6 py-8 text-center">
         <SeveredEdge animate={animate} color={colors[2]} />
         <p className="text-md font-medium text-foreground">
           Didn't find anything for <span className="text-muted-foreground">&ldquo;{query}&rdquo;</span>

--- a/src/components/SearchEmptyState.tsx
+++ b/src/components/SearchEmptyState.tsx
@@ -1,0 +1,186 @@
+import { motion, useReducedMotion } from "framer-motion";
+import { useMemo } from "react";
+
+interface SearchEmptyStateProps {
+  variant: "idle" | "no-results";
+  query?: string;
+  onSeedSelect?: (seed: string) => void;
+}
+
+// A miniature rhizome: node positions and edges for the idle-state constellation
+const NODES = [
+  { x: 30, y: 78, r: 4, color: "var(--chart-1)" },
+  { x: 74, y: 38, r: 5.5, color: "var(--chart-2)" },
+  { x: 128, y: 64, r: 7, color: "var(--chart-3)", pulse: true },
+  { x: 170, y: 26, r: 4, color: "var(--chart-4)" },
+  { x: 196, y: 84, r: 4.5, color: "var(--chart-5)" },
+  { x: 96, y: 102, r: 3, color: "var(--chart-1)" },
+  { x: 154, y: 104, r: 3.5, color: "var(--chart-4)" },
+  { x: 18, y: 28, r: 3, color: "var(--chart-2)" },
+];
+
+const EDGES: [number, number][] = [
+  [0, 1], [1, 2], [2, 3], [2, 4], [1, 5], [2, 6], [7, 0], [3, 4],
+];
+
+const SEED_POOL = {
+  genre: ["shoegaze", "krautrock", "dub techno", "ambient", "post-punk", "trip hop", "zeuhl", "bossa nova"],
+  artist: ["Radiohead", "Aphex Twin", "Alice Coltrane", "Boards of Canada", "Fela Kuti", "Cocteau Twins", "Stereolab", "MF DOOM"],
+};
+
+const pickRandom = (pool: string[], count: number) =>
+  [...pool].sort(() => Math.random() - 0.5).slice(0, count);
+
+function Constellation({ animate }: { animate: boolean }) {
+  return (
+    <motion.svg
+      viewBox="0 0 214 120"
+      className="w-52 text-muted-foreground"
+      aria-hidden="true"
+      animate={animate ? { y: [0, -4, 0] } : undefined}
+      transition={{ duration: 7, repeat: Infinity, ease: "easeInOut" }}
+    >
+      {EDGES.map(([a, b], i) => (
+        <motion.line
+          key={`e-${i}`}
+          x1={NODES[a].x}
+          y1={NODES[a].y}
+          x2={NODES[b].x}
+          y2={NODES[b].y}
+          stroke="currentColor"
+          strokeWidth="1"
+          initial={animate ? { pathLength: 0, opacity: 0 } : false}
+          animate={{ pathLength: 1, opacity: 0.3 }}
+          transition={{ duration: 0.7, delay: 0.15 + i * 0.07, ease: "easeOut" }}
+        />
+      ))}
+      {NODES.map((node, i) => (
+        <g key={`n-${i}`}>
+          {node.pulse && animate && (
+            <motion.circle
+              cx={node.x}
+              cy={node.y}
+              fill="none"
+              stroke={node.color}
+              strokeWidth="1"
+              initial={{ r: node.r, opacity: 0 }}
+              animate={{ r: node.r + 11, opacity: [0, 0.5, 0] }}
+              transition={{ duration: 2.6, repeat: Infinity, delay: 1, ease: "easeOut" }}
+            />
+          )}
+          <motion.circle
+            cx={node.x}
+            cy={node.y}
+            fill={node.color}
+            initial={animate ? { r: 0, opacity: 0 } : { r: node.r, opacity: 1 }}
+            animate={
+              animate
+                ? { r: [node.r, node.r * 1.18, node.r], opacity: 1 }
+                : undefined
+            }
+            transition={{
+              r: { duration: 3 + (i % 3), repeat: Infinity, delay: 0.3 + i * 0.06, ease: "easeInOut" },
+              opacity: { duration: 0.4, delay: 0.3 + i * 0.06 },
+            }}
+          />
+        </g>
+      ))}
+    </motion.svg>
+  );
+}
+
+function SeveredEdge({ animate }: { animate: boolean }) {
+  return (
+    <motion.svg
+      viewBox="0 0 120 40"
+      className="w-28 text-muted-foreground"
+      aria-hidden="true"
+      initial={animate ? { opacity: 0, y: 4 } : false}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.35, ease: "easeOut" }}
+    >
+      <line x1="25" y1="20" x2="52" y2="20" stroke="currentColor" strokeWidth="1" strokeDasharray="3 4" opacity="0.5" />
+      <line x1="66" y1="24" x2="94" y2="22" stroke="currentColor" strokeWidth="1" strokeDasharray="3 4" opacity="0.35" />
+      <circle cx="18" cy="20" r="5" fill="var(--chart-3)" />
+      <circle cx="101" cy="22" r="5" fill="none" stroke="currentColor" strokeWidth="1.25" opacity="0.6" />
+    </motion.svg>
+  );
+}
+
+export function SearchEmptyState({ variant, query, onSeedSelect }: SearchEmptyStateProps) {
+  const reducedMotion = useReducedMotion();
+  const animate = !reducedMotion;
+
+  const seeds = useMemo(
+    () => [
+      ...pickRandom(SEED_POOL.genre, 2),
+      ...pickRandom(SEED_POOL.artist, 2),
+    ],
+    []
+  );
+
+  if (variant === "no-results") {
+    return (
+      <div className="flex flex-col items-center gap-3 px-6 py-12 text-center">
+        <SeveredEdge animate={animate} />
+        <p className="text-sm font-medium text-foreground">
+          Nothing echoes back for <span className="text-muted-foreground">&ldquo;{query}&rdquo;</span>
+        </p>
+        <p className="max-w-xs text-xs leading-relaxed text-muted-foreground">
+          Search forgives a typo or two — try fewer letters, or wander in from a genre instead.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-1 px-6 py-10 text-center">
+      <Constellation animate={animate} />
+      <motion.span
+        className="mt-2 font-mono text-[10px] uppercase tracking-[0.25em] text-muted-foreground"
+        initial={animate ? { opacity: 0 } : false}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.4, delay: 0.5 }}
+      >
+        Rhizome search
+      </motion.span>
+      <motion.p
+        className="text-base font-medium tracking-tight text-foreground"
+        initial={animate ? { opacity: 0, y: 6 } : false}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4, delay: 0.6, ease: "easeOut" }}
+      >
+        Start anywhere
+      </motion.p>
+      <motion.p
+        className="text-xs text-muted-foreground"
+        initial={animate ? { opacity: 0, y: 6 } : false}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4, delay: 0.7, ease: "easeOut" }}
+      >
+        Type an artist or genre — the map unfolds from there.
+      </motion.p>
+      {onSeedSelect && (
+        <div className="mt-4 flex flex-wrap items-center justify-center gap-1.5">
+          {seeds.map((seed, i) => (
+            <motion.button
+              key={seed}
+              type="button"
+              onClick={() => onSeedSelect(seed)}
+              className="flex items-center gap-1.5 rounded-full border bg-background/60 px-3 py-1 text-xs text-muted-foreground transition-colors hover:border-foreground/25 hover:bg-accent hover:text-foreground"
+              initial={animate ? { opacity: 0, y: 6 } : false}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.35, delay: 0.8 + i * 0.07, ease: "easeOut" }}
+            >
+              <span
+                className="size-1.5 rounded-full"
+                style={{ backgroundColor: `var(--chart-${(i % 5) + 1})` }}
+              />
+              {seed}
+            </motion.button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/SearchEmptyState.tsx
+++ b/src/components/SearchEmptyState.tsx
@@ -40,6 +40,15 @@ const EDGES: [number, number][] = [
   [0, 1], [1, 2], [2, 3], [2, 4], [1, 5], [2, 6], [7, 0], [3, 4],
 ];
 
+// Quadratic bezier between two nodes, bowed perpendicular to the line.
+// Alternating direction and varied amounts keep the curves looking hand-drawn
+const edgePath = (a: { x: number; y: number }, b: { x: number; y: number }, i: number) => {
+  const bow = (0.12 + (i % 3) * 0.05) * (i % 2 === 0 ? 1 : -1);
+  const cx = (a.x + b.x) / 2 - (b.y - a.y) * bow;
+  const cy = (a.y + b.y) / 2 + (b.x - a.x) * bow;
+  return `M ${a.x} ${a.y} Q ${cx} ${cy} ${b.x} ${b.y}`;
+};
+
 const SEED_POOL = {
   genre: ["shoegaze", "krautrock", "dub techno", "ambient", "post-punk", "trip hop", "zeuhl", "bossa nova"],
   artist: ["Radiohead", "Aphex Twin", "Alice Coltrane", "Boards of Canada", "Fela Kuti", "Cocteau Twins", "Stereolab", "MF DOOM"],
@@ -92,12 +101,10 @@ function Constellation({ animate, colors }: { animate: boolean; colors: string[]
       transition={{ duration: 7, repeat: Infinity, ease: "easeInOut" }}
     >
       {EDGES.map(([a, b], i) => (
-        <motion.line
+        <motion.path
           key={`e-${i}`}
-          x1={NODES[a].x}
-          y1={NODES[a].y}
-          x2={NODES[b].x}
-          y2={NODES[b].y}
+          d={edgePath(NODES[a], NODES[b], i)}
+          fill="none"
           stroke="currentColor"
           strokeWidth="1"
           initial={animate ? { pathLength: 0, opacity: 0 } : false}

--- a/src/components/SearchEmptyState.tsx
+++ b/src/components/SearchEmptyState.tsx
@@ -2,6 +2,8 @@ import { motion, useReducedMotion } from "framer-motion";
 import { useMemo } from "react";
 import { useTheme } from "next-themes";
 import { CLUSTER_COLORS_DARK, CLUSTER_COLORS_LIGHT } from "@/lib/colors";
+import ArtistBadge from "@/components/ArtistBadge";
+import GenreBadge from "@/components/GenreBadge";
 
 interface SearchEmptyStateProps {
   variant: "idle" | "no-results";
@@ -126,8 +128,8 @@ export function SearchEmptyState({ variant, query, onSeedSelect }: SearchEmptySt
 
   const seeds = useMemo(
     () => [
-      ...pickRandom(SEED_POOL.genre, 2),
-      ...pickRandom(SEED_POOL.artist, 2),
+      ...pickRandom(SEED_POOL.genre, 2).map((label) => ({ label, type: "genre" as const })),
+      ...pickRandom(SEED_POOL.artist, 2).map((label) => ({ label, type: "artist" as const })),
     ],
     []
   );
@@ -168,21 +170,26 @@ export function SearchEmptyState({ variant, query, onSeedSelect }: SearchEmptySt
       {onSeedSelect && (
         <div className="mt-4 flex flex-wrap items-center justify-center gap-1.5">
           {seeds.map((seed, i) => (
-            <motion.button
-              key={seed}
-              type="button"
-              onClick={() => onSeedSelect(seed)}
-              className="flex items-center gap-1.5 rounded-full border bg-background/60 px-3 py-1 text-xs text-muted-foreground transition-colors hover:border-foreground/25 hover:bg-accent hover:text-foreground"
+            <motion.div
+              key={seed.label}
               initial={animate ? { opacity: 0, y: 6 } : false}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.35, delay: 0.8 + i * 0.07, ease: "easeOut" }}
             >
-              <span
-                className="size-1.5 rounded-full"
-                style={{ backgroundColor: colors[i % colors.length] }}
-              />
-              {seed}
-            </motion.button>
+              {seed.type === "genre" ? (
+                <GenreBadge
+                  name={seed.label}
+                  onClick={() => onSeedSelect(seed.label)}
+                  genreColor={colors[i % colors.length]}
+                />
+              ) : (
+                <ArtistBadge
+                  name={seed.label}
+                  onClick={() => onSeedSelect(seed.label)}
+                  genreColor={colors[i % colors.length]}
+                />
+              )}
+            </motion.div>
           ))}
         </div>
       )}

--- a/src/components/SearchEmptyState.tsx
+++ b/src/components/SearchEmptyState.tsx
@@ -1,5 +1,7 @@
 import { motion, useReducedMotion } from "framer-motion";
 import { useMemo } from "react";
+import { useTheme } from "next-themes";
+import { CLUSTER_COLORS_DARK, CLUSTER_COLORS_LIGHT } from "@/lib/colors";
 
 interface SearchEmptyStateProps {
   variant: "idle" | "no-results";
@@ -7,16 +9,26 @@ interface SearchEmptyStateProps {
   onSeedSelect?: (seed: string) => void;
 }
 
-// A miniature rhizome: node positions and edges for the idle-state constellation
+// Hue spread from the graph's cluster palette: red, yellow, teal, blue, purple
+const PALETTE_PICKS = [0, 3, 7, 10, 13];
+
+const usePaletteColors = () => {
+  const { resolvedTheme } = useTheme();
+  const base = resolvedTheme === "light" ? CLUSTER_COLORS_LIGHT : CLUSTER_COLORS_DARK;
+  return PALETTE_PICKS.map((i) => base[i]);
+};
+
+// A miniature rhizome: node positions and edges for the idle-state constellation.
+// `c` indexes into the palette colors above
 const NODES = [
-  { x: 30, y: 78, r: 4, color: "var(--chart-1)" },
-  { x: 74, y: 38, r: 5.5, color: "var(--chart-2)" },
-  { x: 128, y: 64, r: 7, color: "var(--chart-3)", pulse: true },
-  { x: 170, y: 26, r: 4, color: "var(--chart-4)" },
-  { x: 196, y: 84, r: 4.5, color: "var(--chart-5)" },
-  { x: 96, y: 102, r: 3, color: "var(--chart-1)" },
-  { x: 154, y: 104, r: 3.5, color: "var(--chart-4)" },
-  { x: 18, y: 28, r: 3, color: "var(--chart-2)" },
+  { x: 30, y: 78, r: 4, c: 0 },
+  { x: 74, y: 38, r: 5.5, c: 1 },
+  { x: 128, y: 64, r: 7, c: 2, pulse: true },
+  { x: 170, y: 26, r: 4, c: 3 },
+  { x: 196, y: 84, r: 4.5, c: 4 },
+  { x: 96, y: 102, r: 3, c: 0 },
+  { x: 154, y: 104, r: 3.5, c: 3 },
+  { x: 18, y: 28, r: 3, c: 1 },
 ];
 
 const EDGES: [number, number][] = [
@@ -31,7 +43,7 @@ const SEED_POOL = {
 const pickRandom = (pool: string[], count: number) =>
   [...pool].sort(() => Math.random() - 0.5).slice(0, count);
 
-function Constellation({ animate }: { animate: boolean }) {
+function Constellation({ animate, colors }: { animate: boolean; colors: string[] }) {
   return (
     <motion.svg
       viewBox="0 0 214 120"
@@ -61,7 +73,7 @@ function Constellation({ animate }: { animate: boolean }) {
               cx={node.x}
               cy={node.y}
               fill="none"
-              stroke={node.color}
+              stroke={colors[node.c]}
               strokeWidth="1"
               initial={{ r: node.r, opacity: 0 }}
               animate={{ r: node.r + 11, opacity: [0, 0.5, 0] }}
@@ -71,7 +83,7 @@ function Constellation({ animate }: { animate: boolean }) {
           <motion.circle
             cx={node.x}
             cy={node.y}
-            fill={node.color}
+            fill={colors[node.c]}
             initial={animate ? { r: 0, opacity: 0 } : { r: node.r, opacity: 1 }}
             animate={
               animate
@@ -89,7 +101,7 @@ function Constellation({ animate }: { animate: boolean }) {
   );
 }
 
-function SeveredEdge({ animate }: { animate: boolean }) {
+function SeveredEdge({ animate, color }: { animate: boolean; color: string }) {
   return (
     <motion.svg
       viewBox="0 0 120 40"
@@ -101,7 +113,7 @@ function SeveredEdge({ animate }: { animate: boolean }) {
     >
       <line x1="25" y1="20" x2="52" y2="20" stroke="currentColor" strokeWidth="1" strokeDasharray="3 4" opacity="0.5" />
       <line x1="66" y1="24" x2="94" y2="22" stroke="currentColor" strokeWidth="1" strokeDasharray="3 4" opacity="0.35" />
-      <circle cx="18" cy="20" r="5" fill="var(--chart-3)" />
+      <circle cx="18" cy="20" r="5" fill={color} />
       <circle cx="101" cy="22" r="5" fill="none" stroke="currentColor" strokeWidth="1.25" opacity="0.6" />
     </motion.svg>
   );
@@ -110,6 +122,7 @@ function SeveredEdge({ animate }: { animate: boolean }) {
 export function SearchEmptyState({ variant, query, onSeedSelect }: SearchEmptyStateProps) {
   const reducedMotion = useReducedMotion();
   const animate = !reducedMotion;
+  const colors = usePaletteColors();
 
   const seeds = useMemo(
     () => [
@@ -122,12 +135,12 @@ export function SearchEmptyState({ variant, query, onSeedSelect }: SearchEmptySt
   if (variant === "no-results") {
     return (
       <div className="flex flex-col items-center gap-3 px-6 py-12 text-center">
-        <SeveredEdge animate={animate} />
+        <SeveredEdge animate={animate} color={colors[2]} />
         <p className="text-sm font-medium text-foreground">
           Nothing echoes back for <span className="text-muted-foreground">&ldquo;{query}&rdquo;</span>
         </p>
         <p className="max-w-xs text-xs leading-relaxed text-muted-foreground">
-          Search forgives a typo or two — try fewer letters, or wander in from a genre instead.
+          Search forgives a typo or two. Try fewer letters, or wander in from a genre instead.
         </p>
       </div>
     );
@@ -135,17 +148,9 @@ export function SearchEmptyState({ variant, query, onSeedSelect }: SearchEmptySt
 
   return (
     <div className="flex flex-col items-center gap-1 px-6 py-10 text-center">
-      <Constellation animate={animate} />
-      <motion.span
-        className="mt-2 font-mono text-[10px] uppercase tracking-[0.25em] text-muted-foreground"
-        initial={animate ? { opacity: 0 } : false}
-        animate={{ opacity: 1 }}
-        transition={{ duration: 0.4, delay: 0.5 }}
-      >
-        Rhizome search
-      </motion.span>
+      <Constellation animate={animate} colors={colors} />
       <motion.p
-        className="text-base font-medium tracking-tight text-foreground"
+        className="text-xl font-medium tracking-tight text-foreground"
         initial={animate ? { opacity: 0, y: 6 } : false}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.4, delay: 0.6, ease: "easeOut" }}
@@ -153,12 +158,12 @@ export function SearchEmptyState({ variant, query, onSeedSelect }: SearchEmptySt
         Start anywhere
       </motion.p>
       <motion.p
-        className="text-xs text-muted-foreground"
+        className="text-sm text-muted-foreground"
         initial={animate ? { opacity: 0, y: 6 } : false}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.4, delay: 0.7, ease: "easeOut" }}
       >
-        Type an artist or genre — the map unfolds from there.
+        Type an artist or genre and the map unfolds from there.
       </motion.p>
       {onSeedSelect && (
         <div className="mt-4 flex flex-wrap items-center justify-center gap-1.5">
@@ -174,7 +179,7 @@ export function SearchEmptyState({ variant, query, onSeedSelect }: SearchEmptySt
             >
               <span
                 className="size-1.5 rounded-full"
-                style={{ backgroundColor: `var(--chart-${(i % 5) + 1})` }}
+                style={{ backgroundColor: colors[i % colors.length] }}
               />
               {seed}
             </motion.button>

--- a/src/components/SearchEmptyState.tsx
+++ b/src/components/SearchEmptyState.tsx
@@ -1,7 +1,9 @@
 import { motion, useReducedMotion } from "framer-motion";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTheme } from "next-themes";
+import axios from "axios";
 import { CLUSTER_COLORS_DARK, CLUSTER_COLORS_LIGHT } from "@/lib/colors";
+import { serverUrl } from "@/lib/utils";
 import ArtistBadge from "@/components/ArtistBadge";
 import GenreBadge from "@/components/GenreBadge";
 
@@ -9,6 +11,7 @@ interface SearchEmptyStateProps {
   variant: "idle" | "no-results";
   query?: string;
   onSeedSelect?: (seed: string) => void;
+  getArtistImage?: (name: string) => string | undefined;
 }
 
 // Hue spread from the graph's cluster palette: red, yellow, teal, blue, purple
@@ -44,6 +47,40 @@ const SEED_POOL = {
 
 const pickRandom = (pool: string[], count: number) =>
   [...pool].sort(() => Math.random() - 0.5).slice(0, count);
+
+// Resolve images for artist seeds via the search endpoint, keyed by seed name.
+// Local graph lookups rarely cover the random seeds, so this fills the gap
+const useSeedImages = (names: string[]) => {
+  const [images, setImages] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (!names.length) return;
+    const controller = new AbortController();
+    const url = serverUrl();
+    names.forEach(async (name) => {
+      try {
+        const response = await axios.get(`${url}/search/${encodeURIComponent(name)}`, {
+          signal: controller.signal,
+        });
+        const match = (response.data as { name?: string; image?: string; artistCount?: number }[]).find(
+          (item) =>
+            !("artistCount" in item) &&
+            item.name?.toLowerCase() === name.toLowerCase() &&
+            typeof item.image === "string" &&
+            item.image.trim() !== ""
+        );
+        if (match?.image) {
+          setImages((prev) => ({ ...prev, [name]: match.image as string }));
+        }
+      } catch {
+        // Chips fall back to the color dot; a failed image lookup isn't worth surfacing
+      }
+    });
+    return () => controller.abort();
+  }, [names]);
+
+  return images;
+};
 
 function Constellation({ animate, colors }: { animate: boolean; colors: string[] }) {
   return (
@@ -121,7 +158,7 @@ function SeveredEdge({ animate, color }: { animate: boolean; color: string }) {
   );
 }
 
-export function SearchEmptyState({ variant, query, onSeedSelect }: SearchEmptyStateProps) {
+export function SearchEmptyState({ variant, query, onSeedSelect, getArtistImage }: SearchEmptyStateProps) {
   const reducedMotion = useReducedMotion();
   const animate = !reducedMotion;
   const colors = usePaletteColors();
@@ -133,6 +170,11 @@ export function SearchEmptyState({ variant, query, onSeedSelect }: SearchEmptySt
     ],
     []
   );
+  const artistSeedNames = useMemo(
+    () => (variant === "idle" ? seeds.filter((s) => s.type === "artist").map((s) => s.label) : []),
+    [seeds, variant]
+  );
+  const seedImages = useSeedImages(artistSeedNames);
 
   if (variant === "no-results") {
     return (
@@ -187,6 +229,7 @@ export function SearchEmptyState({ variant, query, onSeedSelect }: SearchEmptySt
                   name={seed.label}
                   onClick={() => onSeedSelect(seed.label)}
                   genreColor={colors[i % colors.length]}
+                  imageUrl={getArtistImage?.(seed.label) ?? seedImages[seed.label]}
                 />
               )}
             </motion.div>

--- a/src/components/SearchEmptyState.tsx
+++ b/src/components/SearchEmptyState.tsx
@@ -185,12 +185,12 @@ export function SearchEmptyState({ variant, query, onSeedSelect, getArtistImage 
 
   if (variant === "no-results") {
     return (
-      <div className="flex flex-col items-center gap-3 px-6 py-12 text-center">
+      <div className="flex flex-col items-center gap-1 px-6 py-12 text-center">
         <SeveredEdge animate={animate} color={colors[2]} />
-        <p className="text-sm font-medium text-foreground">
-          Nothing echoes back for <span className="text-muted-foreground">&ldquo;{query}&rdquo;</span>
+        <p className="text-md font-medium text-foreground">
+          Didn't find anything for <span className="text-muted-foreground">&ldquo;{query}&rdquo;</span>
         </p>
-        <p className="max-w-xs text-xs leading-relaxed text-muted-foreground">
+        <p className="max-w-xs text-sm leading-relaxed text-muted-foreground">
           Search forgives a typo or two. Try fewer letters, or wander in from a genre instead.
         </p>
       </div>
@@ -209,7 +209,7 @@ export function SearchEmptyState({ variant, query, onSeedSelect, getArtistImage 
         Start anywhere
       </motion.p>
       <motion.p
-        className="text-sm text-muted-foreground"
+        className="text-md text-muted-foreground"
         initial={animate ? { opacity: 0, y: 6 } : false}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.4, delay: 0.7, ease: "easeOut" }}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -34,6 +34,7 @@ function CommandDialog({
   className,
   showCloseButton = true,
   shouldFilter,
+  loop,
   value,
   onValueChange,
   ...props
@@ -43,6 +44,7 @@ function CommandDialog({
   className?: string
   showCloseButton?: boolean
   shouldFilter?: boolean
+  loop?: boolean
   value?: string
   onValueChange?: (value: string) => void
 }) {
@@ -59,6 +61,7 @@ function CommandDialog({
       >
         <Command
           shouldFilter={shouldFilter}
+          loop={loop}
           value={value}
           onValueChange={onValueChange}
           className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-13 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5"

--- a/src/hooks/useSearch.tsx
+++ b/src/hooks/useSearch.tsx
@@ -10,23 +10,34 @@ const useSearch = (query?: string) => {
     const [searchError, setSearchError] = useState<AxiosError>();
     const [searchLoading, setSearchLoading] = useState(false);
 
-    const search = async () => {
-        if (query) {
+    useEffect(() => {
+        const trimmed = query?.trim();
+        if (!trimmed) {
+            setSearchResults([]);
+            setSearchError(undefined);
+            setSearchLoading(false);
+            return;
+        }
+        const controller = new AbortController();
+        const search = async () => {
             setSearchLoading(true);
             try {
-                const response = await axios.get(`${url}/search/${query}`);
+                const response = await axios.get(`${url}/search/${encodeURIComponent(trimmed)}`, {
+                    signal: controller.signal,
+                });
                 setSearchResults(response.data);
+                setSearchError(undefined);
+                setSearchLoading(false);
             } catch (err) {
+                if (axios.isCancel(err)) return;
                 if (err instanceof AxiosError) {
                     setSearchError(err);
                 }
+                setSearchLoading(false);
             }
-            setSearchLoading(false);
         }
-    }
-
-    useEffect(() => {
         search();
+        return () => controller.abort();
     }, [query]);
 
     return { searchResults, searchLoading, searchError };

--- a/src/index.css
+++ b/src/index.css
@@ -277,3 +277,14 @@ body {
   min-height: 100vh;
   font-family: Geist, sans-serif;
 }
+
+/* Seed chip marquee in the search empty state: row is duplicated once,
+   so sliding from -50% to 0 loops seamlessly while drifting left to right */
+@keyframes search-marquee {
+  from {
+    transform: translateX(-50%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}


### PR DESCRIPTION
Depends on: https://github.com/b-price/rhizome-server/pull/9

## What this does
Overhauls search with better matching, richer UI, and new actions. Artists and genres that were previously missed (correct spelling, fuzzy variants) now surface reliably. The idle state has a polished empty state with a mini-graph constellation and scrolling seed chips. A recents view is accessible as a nested screen inside the dialog.

## Changess

### Loading states
- Skeleton loading rows while results are in-flight (5 rows, varied widths)
- `searchPending` flag covers both the debounce window and the in-flight request so skeletons show immediately on first keystroke

### Empty state
- Idle variant: animated mini-graph constellation (breathing nodes, pulse ring, curved edges), headline, and two-row scrolling marquee of seed artist/genre chips
- No-results variant: severed edge graphic with snap-spark animation, search-forgiveness copy
- Marquee uses the full pool (10 genres + 10 artists), shuffled and interleaved across two rows at different speeds — wide enough that the seamless loop duplicate is never visible
- Artist chips fetch images via the search endpoint on mount

### Actions
- **Surprise Me** — fetches a random node from the server; supports Shift (Play), Alt (View Similar), Cmd (Go To) modifier shortcuts
- **View Recents** — opens nested recents screen inside the dialog
- **Support Rhizome** 
- **Share Rhizome** 
- **Feedback & Requests**, **Toggle Theme** actions
- Arrow-up wraps around from the top of the list to the bottom (loop navigation)
- Dialog closes after selecting any non-navigation action

### Recents view
- Nested screen accessible via the View Recents action or the sidebar's "View all"
- Back button lives in the input row as an icon button; Backspace also navigates back when input is empty
- Entering the recents view scrolls the list to the top
- Recents removed from the root search screen (only visible in the nested view)
- `search:open-recents` event opens the dialog directly into the recents screen from the sidebar
