### PR TITLE
Add error handling for missing genres and artists from URL

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -442,6 +442,12 @@ function App() {
       setShowArtistCard(false);
       setArtistInfoToShow(undefined);
     },
+    onGenreNotFoundFromUrl: () => {
+      toast.error('Genre not found');
+    },
+    onArtistNotFoundFromUrl: () => {
+      toast.error('Artist not found');
+    },
     genresLoaded: genres.length > 0 && !genresLoading,
   });
 

--- a/src/hooks/useUrlState.ts
+++ b/src/hooks/useUrlState.ts
@@ -9,6 +9,8 @@ interface UseUrlStateOptions {
   onArtistFromUrl?: (artist: Artist) => void;
   onGenreClearedFromUrl?: () => void;
   onArtistClearedFromUrl?: () => void;
+  onGenreNotFoundFromUrl?: (slug: string) => void;
+  onArtistNotFoundFromUrl?: (id: string) => void;
   genresLoaded: boolean;
 }
 
@@ -85,7 +87,11 @@ export function useUrlState(options: UseUrlStateOptions): UrlStateResult {
       prevGenreSlug.current = genreSlug;
       if (genreSlug) {
         const genre = callbacksRef.current.findGenreBySlug(genreSlug);
-        if (genre) callbacksRef.current.onGenreFromUrl?.(genre);
+        if (genre) {
+          callbacksRef.current.onGenreFromUrl?.(genre);
+        } else {
+          callbacksRef.current.onGenreNotFoundFromUrl?.(genreSlug);
+        }
       } else {
         callbacksRef.current.onGenreClearedFromUrl?.();
       }
@@ -95,7 +101,11 @@ export function useUrlState(options: UseUrlStateOptions): UrlStateResult {
       prevArtistSlug.current = artistSlug;
       if (artistSlug) {
         callbacksRef.current.fetchArtistById(artistSlug).then((artist) => {
-          if (artist) callbacksRef.current.onArtistFromUrl?.(artist);
+          if (artist) {
+            callbacksRef.current.onArtistFromUrl?.(artist);
+          } else {
+            callbacksRef.current.onArtistNotFoundFromUrl?.(artistSlug);
+          }
         });
       } else {
         callbacksRef.current.onArtistClearedFromUrl?.();


### PR DESCRIPTION
## Summary
Added error handling to gracefully handle cases where a genre or artist referenced in the URL cannot be found in the application's data.

## Key Changes
- Added two new optional callbacks to `UseUrlStateOptions` interface:
  - `onGenreNotFoundFromUrl`: Called when a genre slug from the URL doesn't match any loaded genre
  - `onArtistNotFoundFromUrl`: Called when an artist ID from the URL doesn't match any fetched artist
- Updated genre URL state handler to invoke `onGenreNotFoundFromUrl` when a genre lookup fails
- Updated artist URL state handler to invoke `onArtistNotFoundFromUrl` when an artist lookup fails
- Implemented error callbacks in `App.tsx` to display toast notifications when genres or artists are not found

## Implementation Details
- The error handling follows the existing pattern of optional callbacks in the hook
- Genre not-found detection occurs synchronously during the genre lookup
- Artist not-found detection occurs asynchronously after the artist fetch completes
- User-facing error messages are displayed via toast notifications for better UX when invalid URLs are accessed

https://claude.ai/code/session_01QTb8WRP1ay563MxBfwzkA6