### PR TITLE
remove date stamp span on recents popover

### DIFF
--- a/src/components/RecentsPopover.tsx
+++ b/src/components/RecentsPopover.tsx
@@ -165,9 +165,9 @@ export function RecentsPopover({
                           />
                         </div>
                         <span className="truncate">{item.name}</span>
-                        <span className="text-xs text-muted-foreground">
+                        {/* <span className="text-xs text-muted-foreground">
                           {new Date(item.timestamp).toLocaleDateString()}
-                        </span>
+                        </span> */}
                       </div>
                       <div className="flex items-center flex-shrink-0">
                         <Button


### PR DESCRIPTION
```
changelog:
  description: removed per-item date stamp on recents popover
  type: chor
```
Before
<img width="304" height="457" alt="Screenshot 2026-07-16 at 8 29 20 AM" src="https://github.com/user-attachments/assets/9500435e-0792-45ac-ad46-f694517796a0" />

After
<img width="320" height="486" alt="Screenshot 2026-07-16 at 8 28 45 AM" src="https://github.com/user-attachments/assets/5215dd07-0f9b-4a93-b52d-ce9375f9ed9e" />
e