### PR TITLE
Show artist name in genre filter when exploring related genres

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2875,7 +2875,7 @@ function App() {
                       onClick={() => onTabChange('artists')}
                       className="gap-2"
                     >
-                      Similar artists: {similarArtistAnchor.name}
+                      Similar to {similarArtistAnchor.name}
                       <X className="h-4 w-4" />
                     </Button>
                   </motion.div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -144,6 +144,8 @@ function App() {
     return artistFilterGenreIDs;
   }, [artistFilterGenreIDs]);
   const [genreOperator, setGenreOperator] = useState<'or' | 'and'>('or');
+  // Set when "Explore Related Genres" sets the filter from an artist — cleared on any manual filter change
+  const [genreFilterContextArtistName, setGenreFilterContextArtistName] = useState<string | undefined>(undefined);
   const [selectedArtist, setSelectedArtist] = useState<Artist | undefined>(undefined);
   const [selectedArtistFromSearch, setSelectedArtistFromSearch] = useState<boolean>(false);
   const [artistPreviewStack, setArtistPreviewStack] = useState<Artist[]>([]);
@@ -2498,6 +2500,7 @@ function App() {
           setArtistGenreFilter([]);
           setArtistFilterGenres([]);
         }
+        setGenreFilterContextArtistName(undefined);
         // Only clear genre card if it was showing filtered content
         if (artistGenreFilter.length > 0) {
           setGenreInfoToShow(undefined);
@@ -2512,6 +2515,8 @@ function App() {
           setArtistFilterGenres(selectedIDs.map(s => {
             return { id: s } as Genre
           }));
+          // User is manually adjusting — drop the "for artist" context
+          setGenreFilterContextArtistName(undefined);
         }
         // Also sync genre selection so switching to genre tab shows the filtered genre highlighted
         if (!primitiveArraysEqual(selectedIDs, selectedGenres.map(genre => genre.id))) {
@@ -2617,6 +2622,7 @@ function App() {
     // Apply artist filter - this triggers the artist fetch
     setArtistGenreFilter(matched);
     setArtistFilterGenres(matched); // Set the new filter state
+    setGenreFilterContextArtistName(artist.name);
     setPendingArtistGenreGraph(artist); // Will trigger graph switch when artists load
     setCollectionMode(false);
   };
@@ -2926,6 +2932,7 @@ function App() {
                       onOperatorChange={setGenreOperator}
                       selectedGenreIds={artistGenreFilterIDs}
                       genreColorMap={genreColorMap}
+                      contextArtistName={genreFilterContextArtistName}
                     />
                     <DecadesFilter
                       onDecadeSelectionChange={onDecadeSelectionChange}

--- a/src/components/GenresFilter.tsx
+++ b/src/components/GenresFilter.tsx
@@ -29,6 +29,7 @@ export default function GenresFilter({
   genreColorMap,
   operator = 'or',
   onOperatorChange,
+  contextArtistName,
 }: {
   genres?: Genre[];
   genreClusterModes: GenreClusterMode[];
@@ -38,6 +39,7 @@ export default function GenresFilter({
   genreColorMap?: Map<string, string>;
   operator?: 'or' | 'and';
   onOperatorChange?: (operator: 'or' | 'and') => void;
+  contextArtistName?: string;
 }) {
   const topLevelGenres = useMemo(() => {
     const viaUtil = genres.filter((g) => isRootGenre(g, genreClusterModes));
@@ -138,9 +140,11 @@ export default function GenresFilter({
   if (graphType !== "artists") return null;
 
   const triggerLabel =
-    totalSelected === 1
-      ? (genreById.get(Array.from(selectedIds)[0])?.name ?? "Genres")
-      : "Genres";
+    contextArtistName && totalSelected > 1
+      ? `${contextArtistName}'s genres`
+      : totalSelected === 1
+        ? (genreById.get(Array.from(selectedIds)[0])?.name ?? "Genres")
+        : "Genres";
 
   return (
     <ResponsivePanel


### PR DESCRIPTION
changelog:
  description: When "Explore Related Genres" is triggered for an artist, the genre filter button now displays "[Artist Name]'s genres" instead of the generic "Genres" label
  type: feature
```
## Changes
- When "Explore Related Genres" is triggered for an artist, the genre filter button now displays "[Artist Name]'s genres" instead of the generic "Genres" label
- To match conversational copy, changed "similar artists: [Artist Name]'s" to "Similar to [Artist Name]'s"

<img width="222" height="56" alt="Screenshot 2026-07-16 at 8 34 40 PM" src="https://github.com/user-attachments/assets/1500f55a-9c51-4919-af8a-9b79d040fbc2" />

<img width="208" height="54" alt="Screenshot 2026-07-16 at 8 35 17 PM" src="https://github.com/user-attachments/assets/d8e88202-cfc7-4307-8a74-e86398801ef0" />
